### PR TITLE
Add configs for prompt character

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ To get spacefish working correctly you will need:
 $ fisher matchai/spacefish
 ```
 
+## Customization
+Spacefish works well out of the box, but you can customize almost everything if you want.
+
+* [**Options**](./docs/Options.md) — Tweak section's behavior with tons of options.
+
+You have ability to customize or disable specific elements of Spacefish. All options must be overridden in your `config.fish`.
+
 [spaceship]: https://github.com/denysdovhan/spaceship-prompt
 [fish]: https://fishshell.com/
 [zsh]: http://zsh.org/

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,8 +1,8 @@
 ## Options
 
-You have ability to customize or disable specific elements of Spacefish. All options must be overridden in your `.zshrc` file **after** the theme.
+You have ability to customize or disable specific elements of Spacefish. All options must be overridden in your `.config.fish`.
 
-Colors for sections can be [basic colors](https://wiki.archlinux.org/index.php/zsh#Colors) or [color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
+Colors for sections can be [basic colors](https://fishshell.com/docs/current/commands.html#set_color) or [color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
 
 **Note:** the symbol `·` in this document represents a regular space character ` `, it is used to clearly indicate when an option default value starts or ends with a space.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,0 +1,15 @@
+## Options
+
+You have ability to customize or disable specific elements of Spacefish. All options must be overridden in your `.zshrc` file **after** the theme.
+
+Colors for sections can be [basic colors](https://wiki.archlinux.org/index.php/zsh#Colors) or [color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
+
+**Note:** the symbol `·` in this document represents a regular space character ` `, it is used to clearly indicate when an option default value starts or ends with a space.
+
+### Char
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACEFISH_CHAR_PREFIX` | ` ` | Prefix before prompt character |
+| `SPACEFISH_CHAR_SUFFIX` | `.` | Suffix after prompt character |
+| `SPACEFISH_CHAR_SYMBOL` | `➜ ` | Prompt character to be shown before any command |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,6 +1,6 @@
 ## Options
 
-You have ability to customize or disable specific elements of Spacefish. All options must be overridden in your `.config.fish`.
+You have ability to customize or disable specific elements of Spacefish. All options must be overridden in your `config.fish`.
 
 Colors for sections can be [basic colors](https://fishshell.com/docs/current/commands.html#set_color) or [color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,22 +1,11 @@
-# Set defaults
-set -q SPACEFISH_CHAR_PREFIX ""
-set -q SPACEFISH_CHAR_SYMBOL ➜
-set -q SPACEFISH_CHAR_SUFFIX " "
-
 function fish_prompt
 	set -l brwhite ffffff
 	set -l exit_code $status
-	set -l arrow_color
-	if test $exit_code -eq 0
-		set arrow_color green
-	else
-		set arrow_color red
-	end
 
 	echo -e ''
 	__sf_section_dir cyan $brwhite magenta red
 	__sf_section_exec_time $brwhite yellow
 	echo
-	echo -e -n -s (set_color $arrow_color) "$SPACEFISH_CHAR_PREFIX$SPACEFISH_CHAR_SYMBOL$SPACEFISH_CHAR_SUFFIX"
+	__sf_section_char $brwhite yellow
 	set_color normal
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -6,6 +6,6 @@ function fish_prompt
 	__sf_section_dir cyan $brwhite magenta red
 	__sf_section_exec_time $brwhite yellow
 	echo
-	__sf_section_char
+	__sf_section_char $exit_code
 	set_color normal
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -6,6 +6,6 @@ function fish_prompt
 	__sf_section_dir cyan $brwhite magenta red
 	__sf_section_exec_time $brwhite yellow
 	echo
-	__sf_section_char $brwhite yellow
+	__sf_section_char
 	set_color normal
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,7 +1,7 @@
 # Set defaults
-set -q SPACESHIP_CHAR_PREFIX ""
-set -q SPACESHIP_CHAR_SYMBOL ➜
-set -q SPACESHIP_CHAR_SUFFIX " "
+set -q SPACEFISH_CHAR_PREFIX ""
+set -q SPACEFISH_CHAR_SYMBOL ➜
+set -q SPACEFISH_CHAR_SUFFIX " "
 
 function fish_prompt
 	set -l brwhite ffffff
@@ -17,6 +17,6 @@ function fish_prompt
 	__sf_section_dir cyan $brwhite magenta red
 	__sf_section_exec_time $brwhite yellow
 	echo
-	echo -e -n -s (set_color $arrow_color) "$SPACESHIP_CHAR_PREFIX$SPACESHIP_CHAR_SYMBOL$SPACESHIP_CHAR_SUFFIX"
+	echo -e -n -s (set_color $arrow_color) "$SPACEFISH_CHAR_PREFIX$SPACEFISH_CHAR_SYMBOL$SPACEFISH_CHAR_SUFFIX"
 	set_color normal
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,7 +1,7 @@
 # Set defaults
-set -q SPACESHIP_CHAR_SUFFIX " "
 set -q SPACESHIP_CHAR_PREFIX ""
 set -q SPACESHIP_CHAR_SYMBOL ➜
+set -q SPACESHIP_CHAR_SUFFIX " "
 
 function fish_prompt
 	set -l brwhite ffffff

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,11 +1,10 @@
 function fish_prompt
 	set -l brwhite ffffff
-	set -l exit_code $status
 
 	echo -e ''
 	__sf_section_dir cyan $brwhite magenta red
 	__sf_section_exec_time $brwhite yellow
 	echo
-	__sf_section_char $exit_code
+	__sf_section_char
 	set_color normal
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,3 +1,8 @@
+# Set defaults
+set -q SPACESHIP_CHAR_SUFFIX " "
+set -q SPACESHIP_CHAR_PREFIX ""
+set -q SPACESHIP_CHAR_SYMBOL ➜
+
 function fish_prompt
 	set -l brwhite ffffff
 	set -l exit_code $status
@@ -12,6 +17,6 @@ function fish_prompt
 	__sf_section_dir cyan $brwhite magenta red
 	__sf_section_exec_time $brwhite yellow
 	echo
-	echo -e -n -s (set_color $arrow_color) "➜ "
+	echo -e -n -s (set_color $arrow_color) "$SPACESHIP_CHAR_PREFIX$SPACESHIP_CHAR_SYMBOL$SPACESHIP_CHAR_SUFFIX"
 	set_color normal
 end

--- a/functions/__sf_section_char.fish
+++ b/functions/__sf_section_char.fish
@@ -1,7 +1,3 @@
-__sf_util_set_default SPACEFISH_CHAR_PREFIX ""
-__sf_util_set_default SPACEFISH_CHAR_SYMBOL "➜"
-__sf_util_set_default SPACEFISH_CHAR_SUFFIX " "
-
 function __sf_section_char
 	set -l arrow_color
 	if test $exit_code -eq 0
@@ -10,5 +6,8 @@ function __sf_section_char
 		set arrow_color red
 	end
 
+	__sf_util_set_default SPACEFISH_CHAR_PREFIX ""
+	__sf_util_set_default SPACEFISH_CHAR_SYMBOL "➜"
+	__sf_util_set_default SPACEFISH_CHAR_SUFFIX " "
 	echo -e -n -s (set_color $arrow_color) "$SPACEFISH_CHAR_PREFIX$SPACEFISH_CHAR_SYMBOL$SPACEFISH_CHAR_SUFFIX"
 end

--- a/functions/__sf_section_char.fish
+++ b/functions/__sf_section_char.fish
@@ -1,3 +1,7 @@
+__sf_util_set_default SPACEFISH_CHAR_PREFIX ""
+__sf_util_set_default SPACEFISH_CHAR_SYMBOL "➜"
+__sf_util_set_default SPACEFISH_CHAR_SUFFIX " "
+
 function __sf_section_char
 	set -l arrow_color
 	if test $exit_code -eq 0
@@ -6,5 +10,5 @@ function __sf_section_char
 		set arrow_color red
 	end
 
-	echo -e -n -s (set_color $arrow_color) "➜ "
+	echo -e -n -s (set_color $arrow_color) "$SPACEFISH_CHAR_PREFIX$SPACEFISH_CHAR_SYMBOL$SPACEFISH_CHAR_SUFFIX"
 end

--- a/functions/__sf_section_char.fish
+++ b/functions/__sf_section_char.fish
@@ -1,0 +1,10 @@
+function __sf_section_char
+	set -l arrow_color
+	if test $exit_code -eq 0
+		set arrow_color green
+	else
+		set arrow_color red
+	end
+
+	echo -e -n -s (set_color $arrow_color) "➜ "
+end

--- a/functions/__sf_section_char.fish
+++ b/functions/__sf_section_char.fish
@@ -1,4 +1,8 @@
 function __sf_section_char
+	__sf_util_set_default SPACEFISH_CHAR_PREFIX ""
+	__sf_util_set_default SPACEFISH_CHAR_SYMBOL "➜"
+	__sf_util_set_default SPACEFISH_CHAR_SUFFIX " "
+
 	set -l arrow_color
 	set -l exit_code $status
 
@@ -8,8 +12,5 @@ function __sf_section_char
 		set arrow_color red
 	end
 
-	__sf_util_set_default SPACEFISH_CHAR_PREFIX ""
-	__sf_util_set_default SPACEFISH_CHAR_SYMBOL "➜"
-	__sf_util_set_default SPACEFISH_CHAR_SUFFIX " "
 	echo -e -n -s (set_color $arrow_color) "$SPACEFISH_CHAR_PREFIX$SPACEFISH_CHAR_SYMBOL$SPACEFISH_CHAR_SUFFIX"
 end

--- a/functions/__sf_section_char.fish
+++ b/functions/__sf_section_char.fish
@@ -1,5 +1,7 @@
 function __sf_section_char
 	set -l arrow_color
+	set -l exit_code $status
+
 	if test $exit_code -eq 0
 		set arrow_color green
 	else


### PR DESCRIPTION
Add some configuration options. To use them, add the following to your `config.fish`:

```
# Customize Spacefish
set SPACEFISH_CHAR_PREFIX ""
set SPACEFISH_CHAR_SUFFIX "  "
set SPACEFISH_CHAR_SYMBOL ➜
```