### PR TITLE
Add configs for Git symbol

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -21,6 +21,6 @@ Git section is consists with `git_branch` and `git_status` subsections. It is sh
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACEFISH_GIT_PREFIX` | `on·` | Prefix before Git section |
-| `SPACEFISH_GIT_SUFFIX` | `` | Suffix after Git section |
+| `SPACEFISH_GIT_SUFFIX` | ` ` | Suffix after Git section |
 | `SPACEFISH_GIT_SYMBOL` | ![·](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font](https://github.com/powerline/fonts) |
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -13,3 +13,14 @@ Colors for sections can be [basic colors](https://fishshell.com/docs/current/com
 | `SPACEFISH_CHAR_PREFIX` | ` ` | Prefix before prompt character |
 | `SPACEFISH_CHAR_SUFFIX` | `.` | Suffix after prompt character |
 | `SPACEFISH_CHAR_SYMBOL` | `➜ ` | Prompt character to be shown before any command |
+
+### Git (`git`)
+
+Git section is consists with `git_branch` and `git_status` subsections. It is shown only in Git repositories.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACEFISH_GIT_PREFIX` | `on·` | Prefix before Git section |
+| `SPACEFISH_GIT_SUFFIX` | `` | Suffix after Git section |
+| `SPACEFISH_GIT_SYMBOL` | ![·](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font](https://github.com/powerline/fonts) |
+

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -22,5 +22,5 @@ Git section is consists with `git_branch` and `git_status` subsections. It is sh
 | :------- | :-----: | ------- |
 | `SPACEFISH_GIT_PREFIX` | `on·` | Prefix before Git section |
 | `SPACEFISH_GIT_SUFFIX` | ` ` | Suffix after Git section |
-| `SPACEFISH_GIT_SYMBOL` | ![·](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font](https://github.com/powerline/fonts) |
+| `SPACEFISH_GIT_SYMBOL` | ![·](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font](https://github.com/powerline/fonts)) |
 

--- a/functions/__sf_section_dir.fish
+++ b/functions/__sf_section_dir.fish
@@ -1,11 +1,15 @@
 function __sf_section_dir -a dir_color -a separator_color -a branch_color -a status_color
+	__sf_util_set_default SPACEFISH_GIT_PREFIX ""
+	__sf_util_set_default SPACEFISH_GIT_SYMBOL 
+	__sf_util_set_default SPACEFISH_GIT_SUFFIX ""
+
 	if [ (__sf_util_git_branch) ]
 		set -l git_root (git rev-parse --show-toplevel)
 
 		# Treat the repo root as a top-level directory
 		echo -s -n (set_color -o $dir_color) (string replace $git_root (basename $git_root) $PWD)
 		echo -s -n (set_color -o $separator_color) " on "
-		echo -s -n (set_color -o $branch_color) " " (__sf_util_git_branch) (__sf_section_git $status_color)
+		echo -s -n (set_color -o $branch_color) "$SPACEFISH_GIT_PREFIX$SPACEFISH_GIT_SYMBOL$SPACEFISH_GIT_SUFFIX" (__sf_util_git_branch) (__sf_section_git $status_color)
 	else
 		__sf_util_set_default fish_prompt_pwd_dir_length 0
 		echo -s -n (set_color -o $dir_color) (prompt_pwd)

--- a/functions/__sf_section_dir.fish
+++ b/functions/__sf_section_dir.fish
@@ -1,5 +1,5 @@
 function __sf_section_dir -a dir_color -a separator_color -a branch_color -a status_color
-	__sf_util_set_default SPACEFISH_GIT_PREFIX ""
+	__sf_util_set_default SPACEFISH_GIT_PREFIX "on "
 	__sf_util_set_default SPACEFISH_GIT_SYMBOL 
 	__sf_util_set_default SPACEFISH_GIT_SUFFIX ""
 
@@ -8,8 +8,8 @@ function __sf_section_dir -a dir_color -a separator_color -a branch_color -a sta
 
 		# Treat the repo root as a top-level directory
 		echo -s -n (set_color -o $dir_color) (string replace $git_root (basename $git_root) $PWD)
-		echo -s -n (set_color -o $separator_color) " on "
-		echo -s -n (set_color -o $branch_color) "$SPACEFISH_GIT_PREFIX$SPACEFISH_GIT_SYMBOL$SPACEFISH_GIT_SUFFIX" (__sf_util_git_branch) (__sf_section_git $status_color)
+		echo -s -n (set_color -o $separator_color) " $SPACEFISH_GIT_PREFIX"
+		echo -s -n (set_color -o $branch_color) "$SPACEFISH_GIT_SYMBOL$SPACEFISH_GIT_SUFFIX" (__sf_util_git_branch) (__sf_section_git $status_color)
 	else
 		__sf_util_set_default fish_prompt_pwd_dir_length 0
 		echo -s -n (set_color -o $dir_color) (prompt_pwd)


### PR DESCRIPTION
Add configuration options for the Git symbol.

| Variable | Default | Meaning |
| :------- | :-----: | ------- |
| `SPACEFISH_GIT_PREFIX` | `on·` | Prefix before Git section |
| `SPACEFISH_GIT_SUFFIX` | ` ` | Suffix after Git section |
| `SPACEFISH_GIT_SYMBOL` | ![·](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font](https://github.com/powerline/fonts)) |