### PR TITLE
Revert "Use absolute git dir to find git root directory (#26)"

### DIFF
--- a/functions/__sf_section_dir.fish
+++ b/functions/__sf_section_dir.fish
@@ -24,8 +24,7 @@ function __sf_section_dir -d "Display the current truncated directory"
 	set -l tmp
 
 	if test "$SPACEFISH_DIR_TRUNC_REPO" = "true" -a (__sf_util_git_branch)
-		# Derive repo root from its git directory
-		set -l git_root (string replace '/.git' '' (git rev-parse --absolute-git-dir))
+		set -l git_root (git rev-parse --show-toplevel)
 		# Treat repo root as top level directory
 		set tmp (string replace $git_root (basename $git_root) $PWD)
 	else


### PR DESCRIPTION
This reverts commit 2e044096e83d14b0c3fbc2fe2d3a546d337ffcea.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert the change to dir which uses `--absolute-git-dir` to derive the git directory root.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`--absolute-git-dir` adds a dependency for a git version of 2.13.0 or higher.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
