### PR TITLE
Fix prompt error when accessing .git

### DIFF
--- a/functions/__sf_section_dir.fish
+++ b/functions/__sf_section_dir.fish
@@ -22,9 +22,9 @@ function __sf_section_dir -d "Display the current truncated directory"
 
 	set -l dir
 	set -l tmp
+	set -l git_root (command git rev-parse --show-toplevel ^/dev/null)
 
-	if test "$SPACEFISH_DIR_TRUNC_REPO" = "true" -a (__sf_util_git_branch)
-		set -l git_root (git rev-parse --show-toplevel)
+	if test "$SPACEFISH_DIR_TRUNC_REPO" = "true" -a "$git_root"
 		# Treat repo root as top level directory
 		set tmp (string replace $git_root (basename $git_root) $PWD)
 	else

--- a/tests/__sf_section_dir.test.fish
+++ b/tests/__sf_section_dir.test.fish
@@ -192,6 +192,24 @@ test "Correctly truncates the root of a git directory within another"
 	) = (__sf_section_dir)
 end
 
+test "Doesn't throw an error when in a .git directory"
+	(
+		cd /tmp/tmp-spacefish
+		command git init >/dev/null
+
+		cd /tmp/tmp-spacefish/.git
+
+		set_color --bold fff
+		echo -n "in "
+		set_color normal
+		set_color --bold cyan
+		echo -n "tmp/tmp-spacefish/.git"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_dir)
+
 #
 # Configuration
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a longstanding issue where navigating to the `.git` directory of a project throws errors.
Instead of checking for git branches to identify whether the current directory is a git directory, the prompt now tries to locate the root git directory. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #22 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
