### PR TITLE
Fix compatibility issue with exec_time

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,7 +1,7 @@
 function fish_prompt
 	# Store the exit code of the last command
 	set -g sf_exit_code $status
-	set -g SPACEFISH_VERSION 1.1.0
+	set -g SPACEFISH_VERSION 1.1.1
 
 	# ------------------------------------------------------------------------------
 	# Configuration

--- a/functions/__sf_section_exec_time.fish
+++ b/functions/__sf_section_exec_time.fish
@@ -19,12 +19,15 @@ function __sf_section_exec_time -d "Display the execution time of the last comma
 
 	[ $SPACEFISH_EXEC_TIME_SHOW = false ]; and return
 
-	if test -n "$CMD_DURATION" -a "$CMD_DURATION" -gt (math "$SPACEFISH_EXEC_TIME_ELAPSED * 1000")
-		set -l command_duration (echo $CMD_DURATION | __sf_util_human_time)
+	# Allow for compatibility between fish 2.7 and 3.0
+	set -l command_duration "$CMD_DURATION$cmd_duration"
+
+	if test -n "$command_duration" -a "$command_duration" -gt (math "$SPACEFISH_EXEC_TIME_ELAPSED * 1000")
+		set -l human_command_duration (echo $command_duration | __sf_util_human_time)
 		__sf_lib_section \
 			$SPACEFISH_EXEC_TIME_COLOR \
 			$SPACEFISH_EXEC_TIME_PREFIX \
-			$command_duration \
+			$human_command_duration \
 			$SPACEFISH_EXEC_TIME_SUFFIX
 	end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spacefish",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Fish Shell prompt for Astronauts",
   "repository": "git@github.com:matchai/spacefish.git",
   "author": "Matan Kushner <matchai@me.com>",

--- a/scripts/version.fish
+++ b/scripts/version.fish
@@ -8,3 +8,4 @@ sed -e "s/set -g SPACEFISH_VERSION .*/set -g SPACEFISH_VERSION $new_version/g" $
 mv -- $filename.bak $filename
 
 git add fish_prompt.fish
+git add package.json


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fish v2.X has always used `$CMD_DURATION` as the variable containing the execution time of the last command. Fish v3.X appears to be [changing it to `$cmd_duration`](https://github.com/fish-shell/fish-shell/commit/18b06f3768d6f964dd2c679aee2e80a21c820fe4).

This change makes `exec_time` compatible with either of the above variables.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #65 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
