### PR TITLE
Add kubecontext section to show currently active kubectl context

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -212,6 +212,19 @@ Go section is shown only in directories that contain `Godeps`, `glide.yaml`, any
 | `SPACEFISH_GOLANG_SYMBOL` | `🐹·` | Character to be shown before Go version |
 | `SPACEFISH_GOLANG_COLOR` | `cyan` | Color of Go section |
 
+
+### Kubectl context \(`kubecontext`\)
+
+Kubernetes context is shown everywhere if `kubectl` binary is found.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACEFISH_KUBECONTEXT_SHOW` | `true` | Show current kubectl context |
+| `SPACEFISH_KUBECONTEXT_PREFIX` | `at ` | Prefix before the kubectl section |
+| `SPACEFISH_KUBECONTEXT_SUFFIX` | `$SPACEFISH_PROMPT_DEFAULT_SUFFIX` | Suffix after the kubectl section |
+| `SPACEFISH_KUBECONTEXT_SYMBOL` | `☸️ ` | Character to be shown before kubectl context |
+| `SPACEFISH_KUBECONTEXT_COLOR` | `cyan` | Color of kubectl section |
+
 ### Exec Time \(`exec_time`\)
 
 Execution time of the last command. Will be displayed if it exceeds the set threshold of time.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
   * [Haskell (haskell)](./docs/Options.md#haskell-haskell)
   * [Pyenv (pyenv)](./docs/Options.md#pyenv-pyenv)
   * [Go (golang)](./docs/Options.md#go-golang)
+  * [Kubectl context (kubecontext)](./docs/Options.md#kubectl-context-kubecontext)
   * [Execution time (exec_time)](./docs/Options.md#execution-time-exec_time)
   * [Line Separator (line_sep)](./docs/Options.md#line_sep-node)
   * [Battery (battery)](./docs/Options.md#battery-battery)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -13,7 +13,7 @@ function fish_prompt
 	__sf_util_set_default SPACEFISH_PROMPT_SUFFIXES_SHOW true
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_PREFIX "via "
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_SUFFIX " "
-	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang haskell pyenv exec_time line_sep battery jobs exit_code char
+	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang haskell pyenv kubecontext exec_time line_sep battery jobs exit_code char
 
 	# ------------------------------------------------------------------------------
 	# Sections

--- a/functions/__sf_section_kubecontext.fish
+++ b/functions/__sf_section_kubecontext.fish
@@ -1,0 +1,32 @@
+#
+#  Kubernetes (kubectl)
+#
+# Kubernetes is an open-source system for deployment, scaling,
+# and management of containerized applications.
+# Link: https://kubernetes.io/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+function __sf_section_kubecontext -d "Display the kubernetes context"
+	__sf_util_set_default SPACEFISH_KUBECONTEXT_SHOW true
+	__sf_util_set_default SPACEFISH_KUBECONTEXT_PREFIX "at "
+  __sf_util_set_default SPACEFISH_KUBECONTEXT_SUFFIX $SPACEFISH_PROMPT_DEFAULT_SUFFIX
+	__sf_util_set_default SPACEFISH_KUBECONTEXT_SYMBOL "☸️ "
+	__sf_util_set_default SPACEFISH_KUBECONTEXT_COLOR cyan
+
+	[ $SPACEFISH_KUBECONTEXT_SHOW = false ]; and return
+
+	if not type -q kubectl
+		return
+	end
+
+	set -l sf_kube_context (kubectl config current-context ^/dev/null)
+
+	__sf_lib_section \
+		$SPACEFISH_KUBECONTEXT_COLOR \
+		$SPACEFISH_KUBECONTEXT_PREFIX \
+		"$SPACEFISH_KUBECONTEXT_SYMBOL$sf_kube_context" \
+		$SPACEFISH_KUBECONTEXT_SUFFIX
+
+end

--- a/tests/__sf_section_kubecontext.test.fish
+++ b/tests/__sf_section_kubecontext.test.fish
@@ -1,0 +1,78 @@
+source $DIRNAME/spacefish_test_setup.fish
+source $DIRNAME/mock.fish
+
+function setup
+	spacefish_test_setup
+	mock kubectl 0 "echo \"testkube\""
+end
+
+test "Prints section "
+	(
+		set_color --bold fff
+		echo -n "at "
+		set_color normal
+		set_color --bold cyan
+		echo -n "☸️ testkube"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_kubecontext)
+end
+
+test "Changing SPACEFISH_KUBECONTEXT_SYMBOL changes the displayed character"
+	(
+		set SPACEFISH_KUBECONTEXT_SYMBOL "· "
+
+		set_color --bold fff
+		echo -n "at "
+		set_color normal
+		set_color --bold cyan
+		echo -n "· testkube"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_kubecontext)
+end
+
+test "Changing SPACEFISH_KUBECONTEXT_PREFIX changes the character prefix"
+	(
+		set sf_exit_code 0
+		set SPACEFISH_KUBECONTEXT_PREFIX ·
+
+		set_color --bold fff
+		echo -n "·"
+		set_color normal
+		set_color --bold cyan
+		echo -n "☸️ testkube"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_kubecontext)
+end
+
+test "Changing SPACEFISH_KUBECONTEXT_SUFFIX changes the character prefix"
+	(
+		set sf_exit_code 0
+		set SPACEFISH_KUBECONTEXT_SUFFIX ·
+
+		set_color --bold fff
+		echo -n "at "
+		set_color normal
+		set_color --bold cyan
+		echo -n "☸️ testkube"
+		set_color normal
+		set_color --bold fff
+		echo -n "·"
+		set_color normal
+	) = (__sf_section_kubecontext)
+end
+
+test "Doesn't display node when SPACEFISH_KUBECONTEXT_SHOW is set to 'false'"
+	(
+		set SPACEFISH_KUBECONTEXT_SHOW false
+	) = (__sf_section_kubecontext)
+end
+


### PR DESCRIPTION
Issue: #73

Add kubecontext section

## Description
Shows currently active kubectl context

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/46186/46321014-ad05be80-c5fe-11e8-900a-d2b9744f013f.png)


## How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
