### PR TITLE
Add kubernetes namespace to kubecontext section when present

### DIFF
--- a/functions/__sf_section_kubecontext.fish
+++ b/functions/__sf_section_kubecontext.fish
@@ -21,12 +21,17 @@ function __sf_section_kubecontext -d "Display the kubernetes context"
 		return
 	end
 
-	set -l sf_kube_context (kubectl config current-context ^/dev/null)
+	set -l _kube_context (kubectl config current-context ^/dev/null)
+	set -l _kube_ns (kubectl config view -o=jsonpath="{.contexts[?(@.name==\"$_kube_context\")].context.namespace}" ^/dev/null)
+
+	if [ $_kube_ns != "" ]
+		set _kube_context "$_kube_context.$_kube_ns"
+	end
 
 	__sf_lib_section \
 		$SPACEFISH_KUBECONTEXT_COLOR \
 		$SPACEFISH_KUBECONTEXT_PREFIX \
-		"$SPACEFISH_KUBECONTEXT_SYMBOL$sf_kube_context" \
+		"$SPACEFISH_KUBECONTEXT_SYMBOL$_kube_context" \
 		$SPACEFISH_KUBECONTEXT_SUFFIX
 
 end

--- a/tests/__sf_section_kubecontext.test.fish
+++ b/tests/__sf_section_kubecontext.test.fish
@@ -12,7 +12,7 @@ test "Prints section"
 		echo -n "at "
 		set_color normal
 		set_color --bold cyan
-		echo -n "☸️ testkube"
+		echo -n "☸️ testkube.testkube"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -28,7 +28,7 @@ test "Changing SPACEFISH_KUBECONTEXT_SYMBOL changes the displayed character"
 		echo -n "at "
 		set_color normal
 		set_color --bold cyan
-		echo -n "· testkube"
+		echo -n "· testkube.testkube"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -45,7 +45,7 @@ test "Changing SPACEFISH_KUBECONTEXT_PREFIX changes the character prefix"
 		echo -n "·"
 		set_color normal
 		set_color --bold cyan
-		echo -n "☸️ testkube"
+		echo -n "☸️ testkube.testkube"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -62,7 +62,7 @@ test "Changing SPACEFISH_KUBECONTEXT_SUFFIX changes the character prefix"
 		echo -n "at "
 		set_color normal
 		set_color --bold cyan
-		echo -n "☸️ testkube"
+		echo -n "☸️ testkube.testkube"
 		set_color normal
 		set_color --bold fff
 		echo -n "·"


### PR DESCRIPTION
Shows active kubectl namespace in addition to context rendered as `$symbol $context.$namespace`


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/46186/46473970-55827100-c7ff-11e8-85ad-78f936f3c5b0.png)


## How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
