### PR TITLE
Added changes from Spaceship upstream! 🚀⭐

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -223,6 +223,7 @@ Rust section is shown only in directories that contain `Cargo.toml` or any other
 | `SPACEFISH_RUST_SUFFIX` | `$SPACEFISH_PROMPT_DEFAULT_SUFFIX` | Suffix after the Rust section |
 | `SPACEFISH_RUST_SYMBOL` | `𝗥·` | Character to be shown before Rust version |
 | `SPACEFISH_RUST_COLOR` | `red` | Color of Rust section |
+| `SPACEFISH_RUST_VERBOSE_VERSION` | `false` | Show what branch is being used, if any. (Beta, Nightly) |
 
 ### Kubectl context \(`kubecontext`\)
 

--- a/functions/__sf_section_rust.fish
+++ b/functions/__sf_section_rust.fish
@@ -31,10 +31,10 @@ function __sf_section_rust -d "Display the current Rust version"
 		return
 	end
 
-	set -l rust_version (rustc --version | cut -d' ' -f2)
+	set -l rust_version (rustc --version | string split ' ')[2]
 
 	if test $SPACEFISH_RUST_VERBOSE_VERSION = false
-        set rust_version (echo $rust_version | cut -d'-' -f1) # Cut off -suffixes from version. "v1.30.0-beta.11" or "v1.30.0-nightly"
+        set rust_version (string split '-' $rust_version)[1] # Cut off -suffixes from version. "v1.30.0-beta" vs "v1.30.0"
 	end
 
 	__sf_lib_section \

--- a/functions/__sf_section_rust.fish
+++ b/functions/__sf_section_rust.fish
@@ -14,6 +14,7 @@ function __sf_section_rust -d "Display the current Rust version"
 	__sf_util_set_default SPACEFISH_RUST_SUFFIX $SPACEFISH_PROMPT_DEFAULT_SUFFIX
 	__sf_util_set_default SPACEFISH_RUST_SYMBOL "𝗥 "
 	__sf_util_set_default SPACEFISH_RUST_COLOR red
+	__sf_util_set_default SPACEFISH_RUST_VERBOSE_VERSION false
 
 	# ------------------------------------------------------------------------------
 	# Section
@@ -31,6 +32,10 @@ function __sf_section_rust -d "Display the current Rust version"
 	end
 
 	set -l rust_version (rustc --version | cut -d' ' -f2)
+
+	if test $SPACEFISH_RUST_VERBOSE_VERSION = false
+        set rust_version (echo $rust_version | cut -d'-' -f1) # Cut off -suffixes from version. "v1.30.0-beta.11" or "v1.30.0-nightly"
+	end
 
 	__sf_lib_section \
 		$SPACEFISH_RUST_COLOR \

--- a/tests/__sf_section_rust.test.fish
+++ b/tests/__sf_section_rust.test.fish
@@ -3,7 +3,7 @@ source $DIRNAME/mock.fish
 
 function setup
 	spacefish_test_setup
-	mock rustc 0 "echo \"rustc 1.28.0 (9634041f0 2018-07-30)\""
+	mock rustc 0 "echo \"rustc 1.28.0-nightly (9634041f0 2018-07-30)\""
 	mkdir -p /tmp/tmp-spacefish
 	touch /tmp/tmp-spacefish/Cargo.toml
 	cd /tmp/tmp-spacefish
@@ -96,6 +96,23 @@ test "Changing SPACEFISH_RUST_SUFFIX changes the character prefix"
 		set_color normal
 		set_color --bold fff
 		echo -n "·"
+		set_color normal
+	) = (__sf_section_rust)
+end
+
+test "Prints verbose version when configured to do so"
+	(
+		touch /tmp/tmp-spacefish/testfile.rs
+        set SPACEFISH_RUST_VERBOSE_VERSION true
+	
+		set_color --bold fff
+		echo -n "via "
+		set_color normal
+		set_color --bold red
+		echo -n "𝗥 v1.28.0-nightly"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
 		set_color normal
 	) = (__sf_section_rust)
 end


### PR DESCRIPTION

## Description
This adds a config option to enable/disable verbose versioning,
which should be disabled by default.

**Upstream pull request:**
https://github.com/denysdovhan/spaceship-prompt/pull/521

<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original rust section displays the verbose version by default. For example: `v1.30.0-nightly`, `v1.30.0-beta` or `v1.30.0`, depending on what branch you were using. (Stable not having a suffix)

This change makes non-verbose version numbers the default `v1.30.0`, and a config option to enable it only if wanted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
(All three)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**

I have tested using the `./tests/run.fish` locally, as well as running logical snippets in my shell to make sure the syntax is correct.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
