### PR TITLE
Add section to show the active AWS profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Spacefish is a minimalistic, powerful and extremely customizable <a href="https:
   * `=` — unmerged changes;
   * `⇡` — ahead of remote branch;
   * `⇣` — behind of remote branch;
-  * `⇕` — diverged chages.
+  * `⇕` — diverged changes.
 * Indicator for jobs in the background (`✦`).
 * Current Node.js version, through nvm/nodenv/n (`⬢`).
 * Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).
@@ -76,6 +76,7 @@ Spacefish is a minimalistic, powerful and extremely customizable <a href="https:
 * Current PHP version (`🐘`).
 * Current Rust version (`𝗥`).
 * Current version of Haskell GHC Compiler, defined in stack.yaml file (`λ`).
+* Current Amazon Web Services (AWS) profile (`☁️`) ([Using named profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html)).
 * Current Python pyenv (`🐍`).
 * Current Kubectl context (`☸️`).
 * Package version, if there is a package in current directory (`📦`).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -15,7 +15,7 @@ The order also defines which sections that Spacefish loads. If you're struggling
 The default order is:
 
 ```fish
-    set SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell pyenv kubecontext exec_time line_sep battery jobs exit_code char
+    set SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell aws pyenv kubecontext exec_time line_sep battery jobs exit_code char
 ```
 
 ### Prompt
@@ -187,6 +187,18 @@ Ruby section is shown only in directories that contain `stack.yaml`.
 | `SPACEFISH_HASKELL_SUFFIX` | `$SPACEFISH_PROMPT_DEFAULT_SUFFIX` | Suffix after Haskell section |
 | `SPACEFISH_HASKELL_SYMBOL` | `λ·` | Character to be shown before Haskell version |
 | `SPACEFISH_HASKELL_COLOR` | `red` | Color of Haskell section |
+
+### Amazon Web Services (AWS) (`aws`)
+
+Shows selected Amazon Web Services profile configured using  [`AWS_PROFILE`](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html) variable.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_AWS_SHOW` | `true` | Show current selected AWS-cli profile or not |
+| `SPACESHIP_AWS_PREFIX` | `using·` | Prefix before the AWS section |
+| `SPACESHIP_AWS_SUFFIX` | `$SPACEFISH_PROMPT_DEFAULT_SUFFIX` | Suffix after the AWS section |
+| `SPACESHIP_AWS_SYMBOL` | `☁️·` | Character to be shown before AWS profile |
+| `SPACESHIP_AWS_COLOR` | `ff8700` | Color of AWS section |
 
 ### Pyenv \(`pyenv`\)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
   * [Node (node)](./docs/Options.md#nodejs-node)
   * [Ruby (ruby)](./docs/Options.md#ruby-ruby)
   * [Haskell (haskell)](./docs/Options.md#haskell-haskell)
+  * [Amazon Web Services (aws)](./docs/Options.md#amazon-web-services-aws-aws)
   * [Pyenv (pyenv)](./docs/Options.md#pyenv-pyenv)
   * [Go (golang)](./docs/Options.md#go-golang)
   * [PHP (php)](./docs/Options.md#php-php)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -13,7 +13,7 @@ function fish_prompt
 	__sf_util_set_default SPACEFISH_PROMPT_SUFFIXES_SHOW true
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_PREFIX "via "
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_SUFFIX " "
-	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell pyenv kubecontext exec_time line_sep battery jobs exit_code char
+	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell aws pyenv kubecontext exec_time line_sep battery jobs exit_code char
 
 	# ------------------------------------------------------------------------------
 	# Sections

--- a/functions/__sf_section_aws.fish
+++ b/functions/__sf_section_aws.fish
@@ -1,0 +1,39 @@
+#
+# Amazon Web Services (AWS)
+#
+# The AWS Command Line Interface (CLI) is a unified tool to manage AWS services.
+# Link: https://aws.amazon.com/cli/
+
+function __sf_section_aws -d "Display the selected aws profile"
+	# ------------------------------------------------------------------------------
+	# Configuration
+	# ------------------------------------------------------------------------------
+
+	__sf_util_set_default SPACEFISH_AWS_SHOW true
+	__sf_util_set_default SPACEFISH_AWS_PREFIX "using "
+	__sf_util_set_default SPACEFISH_AWS_SUFFIX $SPACEFISH_PROMPT_DEFAULT_SUFFIX
+	__sf_util_set_default SPACEFISH_AWS_SYMBOL "☁️ "
+	__sf_util_set_default SPACEFISH_AWS_COLOR ff8700
+
+	# ------------------------------------------------------------------------------
+	# Section
+	# ------------------------------------------------------------------------------
+
+	# Show the selected AWS-cli profile
+	[ $SPACEFISH_AWS_SHOW = false ]; and return
+
+	# Ensure the aws command is available
+	type -q aws; or return
+
+	# Early return if there's no AWS_PROFILE, or it's set to default
+	if test -z "$AWS_PROFILE" \
+		-o "$AWS_PROFILE" = "default"
+		return
+	end
+
+	__sf_lib_section \
+		$SPACEFISH_AWS_COLOR \
+		$SPACEFISH_AWS_PREFIX \
+		"$SPACEFISH_AWS_SYMBOL""$AWS_PROFILE" \
+		$SPACEFISH_AWS_SUFFIX
+end

--- a/tests/__sf_section_aws.test.fish
+++ b/tests/__sf_section_aws.test.fish
@@ -1,0 +1,90 @@
+source $DIRNAME/spacefish_test_setup.fish
+source $DIRNAME/mock.fish
+
+function setup
+	spacefish_test_setup
+	set -g AWS_PROFILE user1
+end
+
+test "Prints section when AWS_PROFILE is set"
+	(
+		set_color --bold fff
+		echo -n "using "
+		set_color normal
+		set_color --bold ff8700
+		echo -n "☁️ user1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_aws)
+end
+
+test "Doesn't print the section when AWS_PROFILE isn't set"
+	(
+		set --erase AWS_PROFILE
+	) = (__sf_section_aws)
+end
+
+test "Doesn't print the section when AWS_PROFILE is set to \"default\""
+	(
+		set AWS_PROFILE default
+	) = (__sf_section_aws)
+end
+
+test "Changing SPACEFISH_AWS_SYMBOL changes the displayed character"
+	(
+		set SPACEFISH_AWS_SYMBOL "· "
+
+		set_color --bold fff
+		echo -n "using "
+		set_color normal
+		set_color --bold ff8700
+		echo -n "· user1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_aws)
+end
+
+test "Changing SPACEFISH_AWS_PREFIX changes the character prefix"
+	(
+		set sf_exit_code 0
+		set SPACEFISH_AWS_PREFIX ·
+
+		set_color --bold fff
+		echo -n "·"
+		set_color normal
+		set_color --bold ff8700
+		echo -n "☁️ user1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_aws)
+end
+
+test "Changing SPACEFISH_AWS_SUFFIX changes the character suffix"
+	(
+		set sf_exit_code 0
+		set SPACEFISH_AWS_SUFFIX ·
+
+		set_color --bold fff
+		echo -n "using "
+		set_color normal
+		set_color --bold ff8700
+		echo -n "☁️ user1"
+		set_color normal
+		set_color --bold fff
+		echo -n "·"
+		set_color normal
+	) = (__sf_section_aws)
+end
+
+test "doesn't display the section when SPACEFISH_AWS_SHOW is set to \"false\""
+	(
+		set SPACEFISH_AWS_SHOW false
+	) = (__sf_section_aws)
+end
+

--- a/tests/__sf_section_aws.test.fish
+++ b/tests/__sf_section_aws.test.fish
@@ -3,6 +3,7 @@ source $DIRNAME/mock.fish
 
 function setup
 	spacefish_test_setup
+	mock aws 0
 	set -g AWS_PROFILE user1
 end
 

--- a/tests/__sf_section_golang.test.fish
+++ b/tests/__sf_section_golang.test.fish
@@ -116,7 +116,7 @@ test "Changing SPACEFISH_GOLANG_PREFIX changes the character prefix"
 	) = (__sf_section_golang)
 end
 
-test "Changing SPACEFISH_GOLANG_SUFFIX changes the character prefix"
+test "Changing SPACEFISH_GOLANG_SUFFIX changes the character suffix"
 	(
 		set sf_exit_code 0
 		set SPACEFISH_GOLANG_SUFFIX ·
@@ -133,7 +133,7 @@ test "Changing SPACEFISH_GOLANG_SUFFIX changes the character prefix"
 	) = (__sf_section_golang)
 end
 
-test "Doesn't display node when SPACEFISH_GOLANG_SHOW is set to 'false'"
+test "doesn't display the section when SPACEFISH_GOLANG_SHOW is set to \"false\""
 	(
 		set SPACEFISH_GOLANG_SHOW false
 	) = (__sf_section_golang)

--- a/tests/__sf_section_host.test.fish
+++ b/tests/__sf_section_host.test.fish
@@ -27,7 +27,7 @@ test "Correctly shows hostname upon SSH connection"
 	) = (__sf_section_host)
 end
 
-test "Displays user when SPACEFISH_HOST_SHOW is set to 'always'"
+test "Displays user when SPACEFISH_HOST_SHOW is set to \"always\""
 	(
 		set SPACEFISH_HOST_SHOW always
 
@@ -43,7 +43,7 @@ test "Displays user when SPACEFISH_HOST_SHOW is set to 'always'"
 	) = (__sf_section_host)
 end
 
-test "Displays user when SPACEFISH_HOST_SHOW is set to 'always', over SSH"
+test "Displays user when SPACEFISH_HOST_SHOW is set to \"always\", over SSH"
 	(
 		set SPACEFISH_HOST_SHOW always
 		set SSH_CONNECTION "192.168.0.100 12345 192.168.0.101 22"
@@ -60,7 +60,7 @@ test "Displays user when SPACEFISH_HOST_SHOW is set to 'always', over SSH"
 	) = (__sf_section_host)
 end
 
-test "Doesn't display user when SPACEFISH_HOST_SHOW is set to 'false'"
+test "doesn't display the section when SPACEFISH_HOST_SHOW is set to \"false\""
 	(
 		set SPACEFISH_HOST_SHOW false
 	) = (__sf_section_host)

--- a/tests/__sf_section_kubecontext.test.fish
+++ b/tests/__sf_section_kubecontext.test.fish
@@ -53,7 +53,7 @@ test "Changing SPACEFISH_KUBECONTEXT_PREFIX changes the character prefix"
 	) = (__sf_section_kubecontext)
 end
 
-test "Changing SPACEFISH_KUBECONTEXT_SUFFIX changes the character prefix"
+test "Changing SPACEFISH_KUBECONTEXT_SUFFIX changes the character suffix"
 	(
 		set sf_exit_code 0
 		set SPACEFISH_KUBECONTEXT_SUFFIX ·
@@ -70,7 +70,7 @@ test "Changing SPACEFISH_KUBECONTEXT_SUFFIX changes the character prefix"
 	) = (__sf_section_kubecontext)
 end
 
-test "Doesn't display node when SPACEFISH_KUBECONTEXT_SHOW is set to 'false'"
+test "doesn't display the section when SPACEFISH_KUBECONTEXT_SHOW is set to \"false\""
 	(
 		set SPACEFISH_KUBECONTEXT_SHOW false
 	) = (__sf_section_kubecontext)

--- a/tests/__sf_section_node.test.fish
+++ b/tests/__sf_section_node.test.fish
@@ -176,7 +176,7 @@ test "Setting SPACEFISH_NODE_DEFAULT_VERSION to the current version disables the
 	) = (__sf_section_node)
 end
 
-test "Doesn't display node when SPACEFISH_NODE_SHOW is set to 'false'"
+test "doesn't display the section when SPACEFISH_NODE_SHOW is set to \"false\""
 	(
 		set SPACEFISH_NODE_SHOW false
 	) = (__sf_section_node)

--- a/tests/__sf_section_php.test.fish
+++ b/tests/__sf_section_php.test.fish
@@ -85,7 +85,7 @@ test "Changing SPACEFISH_PHP_PREFIX changes the character prefix"
 	) = (__sf_section_php)
 end
 
-test "Changing SPACEFISH_PHP_SUFFIX changes the character prefix"
+test "Changing SPACEFISH_PHP_SUFFIX changes the character suffix"
 	(
 		set sf_exit_code 0
 		set SPACEFISH_PHP_SUFFIX ·
@@ -102,7 +102,7 @@ test "Changing SPACEFISH_PHP_SUFFIX changes the character prefix"
 	) = (__sf_section_php)
 end
 
-test "Doesn't display node when SPACEFISH_PHP_SHOW is set to 'false'"
+test "doesn't display the section when SPACEFISH_PHP_SHOW is set to \"false\""
 	(
 		set SPACEFISH_PHP_SHOW false
 	) = (__sf_section_php)

--- a/tests/__sf_section_pyenv.test.fish
+++ b/tests/__sf_section_pyenv.test.fish
@@ -66,7 +66,7 @@ test "Changing SPACEFISH_PYENV_SYMBOL changes the displayed character"
 	) = (__sf_section_pyenv)
 end
 
-test "Changing SPACEFISH_PHP_PREFIX changes the character prefix"
+test "Changing SPACEFISH_PYENV_PREFIX changes the character prefix"
 	(
 		set sf_exit_code 0
 		set SPACEFISH_PYENV_PREFIX ·
@@ -83,7 +83,7 @@ test "Changing SPACEFISH_PHP_PREFIX changes the character prefix"
 	) = (__sf_section_pyenv)
 end
 
-test "Changing SPACEFISH_PYENV_SUFFIX changes the character prefix"
+test "Changing SPACEFISH_PYENV_SUFFIX changes the character suffix"
 	(
 		set sf_exit_code 0
 		set SPACEFISH_PYENV_SUFFIX ·
@@ -100,7 +100,7 @@ test "Changing SPACEFISH_PYENV_SUFFIX changes the character prefix"
 	) = (__sf_section_pyenv)
 end
 
-test "Doesn't display node when SPACEFISH_PYENV_SHOW is set to 'false'"
+test "doesn't display the section when SPACEFISH_PYENV_SHOW is set to \"false\""
 	(
 		set SPACEFISH_PYENV_SHOW false
 	) = (__sf_section_pyenv)

--- a/tests/__sf_section_rust.test.fish
+++ b/tests/__sf_section_rust.test.fish
@@ -83,7 +83,7 @@ test "Changing SPACEFISH_RUST_PREFIX changes the character prefix"
 	) = (__sf_section_rust)
 end
 
-test "Changing SPACEFISH_RUST_SUFFIX changes the character prefix"
+test "Changing SPACEFISH_RUST_SUFFIX changes the character suffix"
 	(
 		set sf_exit_code 0
 		set SPACEFISH_RUST_SUFFIX ·
@@ -117,7 +117,7 @@ test "Prints verbose version when configured to do so"
 	) = (__sf_section_rust)
 end
 
-test "Doesn't display node when SPACEFISH_RUST_SHOW is set to 'false'"
+test "doesn't display the section when SPACEFISH_RUST_SHOW is set to \"false\""
 	(
 		set SPACEFISH_RUST_SHOW false
 	) = (__sf_section_rust)

--- a/tests/__sf_section_user.test.fish
+++ b/tests/__sf_section_user.test.fish
@@ -68,7 +68,7 @@ test "Changes user color when logged in as root"
 	) = (__sf_section_user)
 end
 
-test "Displays user when SPACEFISH_USER_SHOW is set to 'always'"
+test "Displays user when SPACEFISH_USER_SHOW is set to \"always\""
 	(
 		set SPACEFISH_USER_SHOW always
 
@@ -84,7 +84,7 @@ test "Displays user when SPACEFISH_USER_SHOW is set to 'always'"
 	) = (__sf_section_user)
 end
 
-test "Doesn't display user when SPACEFISH_USER_SHOW is set to 'false'"
+test "Doesn't display user when SPACEFISH_USER_SHOW is set to \"false\""
 	(
 		set SPACEFISH_USER_SHOW false
 	) = (__sf_section_user)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implement AWS profile section based on the implementation on spaceship.
- Show profile name when it exists and isn't set to "default"
- Write tests for the new section
	- Clean up a whole lot of other tests
- Update documentation with the new section

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #85 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x	] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4658208/46931783-79b12f80-d001-11e8-9235-af2fcbd8c1d4.png)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
