### PR TITLE
Add section to show the Docker version and Machine name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Spacefish is a minimalistic, powerful and extremely customizable <a href="https:
   * `⇕` — diverged chages.
 * Indicator for jobs in the background (`✦`).
 * Current Node.js version, through nvm/nodenv/n (`⬢`).
-* Current Docker version (`🐳`).
+* Current Docker version and connected machine (`🐳`).
 * Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).
 * Current Go version (`🐹`).
 * Current PHP version (`🐘`).

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Spacefish is a minimalistic, powerful and extremely customizable <a href="https:
   * `⇕` — diverged chages.
 * Indicator for jobs in the background (`✦`).
 * Current Node.js version, through nvm/nodenv/n (`⬢`).
+* Current Docker version (`🐳`).
 * Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).
 * Current Go version (`🐹`).
 * Current PHP version (`🐘`).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -164,6 +164,19 @@ If you set `SPACEFISH_NODE_DEFAULT_VERSION` to the default Node.js version and y
 | `SPACEFISH_NODE_DEFAULT_VERSION` | ` ` | Node.js version to be treated as default |
 | `SPACEFISH_NODE_COLOR` | `green` | Color of Node.js section |
 
+### Docker (`docker`)
+
+Docker section is shown only in directories that contain `Dockerfile` or `docker-compose.yml` and also if the `$COMPOSE_FILE` is set.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACEFISH_DOCKER_SHOW` | `true` | Show current Docker version |
+| `SPACEFISH_DOCKER_PREFIX` | `$SPACEFISH_PROMPT_DEFAULT_PREFIX` | Prefix before the Docker section |
+| `SPACEFISH_DOCKER_SUFFIX` | `$SPACEFISH_PROMPT_DEFAULT_SUFFIX` | Suffix after the Docker section |
+| `SPACEFISH_DOCKER_SYMBOL` | `🐳·` | Character to be shown before Docker version |
+| `SPACEFISH_DOCKER_COLOR` | `cyan` | Color of Docker section |
+| `SPACEFISH_DOCKER_VERBOSE_VERSION` | `false` | Show full version name. (Beta, Nightly) |
+
 ### Ruby \(`ruby`\)
 
 Ruby section is shown only in directories that contain `Gemfile`, or `Rakefile`, or any other file with `.rb` extension.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
     * [Git status (git_status)](./docs/Options.md#git-status-gitstatus)
   * [Package version (package)](./docs/Options.md#package-version-package)
   * [Node (node)](./docs/Options.md#nodejs-node)
+  * [Docker (docker)](./docs/Options.md#docker-docker)
   * [Ruby (ruby)](./docs/Options.md#ruby-ruby)
   * [Haskell (haskell)](./docs/Options.md#haskell-haskell)
   * [Pyenv (pyenv)](./docs/Options.md#pyenv-pyenv)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -13,7 +13,7 @@ function fish_prompt
 	__sf_util_set_default SPACEFISH_PROMPT_SUFFIXES_SHOW true
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_PREFIX "via "
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_SUFFIX " "
-	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell docker pyenv kubecontext exec_time line_sep battery jobs exit_code char
+	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell docker aws pyenv kubecontext exec_time line_sep battery jobs exit_code char
 
 	# ------------------------------------------------------------------------------
 	# Sections

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -13,7 +13,7 @@ function fish_prompt
 	__sf_util_set_default SPACEFISH_PROMPT_SUFFIXES_SHOW true
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_PREFIX "via "
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_SUFFIX " "
-	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node docker ruby golang php rust haskell pyenv kubecontext exec_time line_sep battery jobs exit_code char
+	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell docker pyenv kubecontext exec_time line_sep battery jobs exit_code char
 
 	# ------------------------------------------------------------------------------
 	# Sections

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -13,7 +13,7 @@ function fish_prompt
 	__sf_util_set_default SPACEFISH_PROMPT_SUFFIXES_SHOW true
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_PREFIX "via "
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_SUFFIX " "
-	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell pyenv kubecontext exec_time line_sep battery jobs exit_code char
+	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node docker ruby golang php rust haskell pyenv kubecontext exec_time line_sep battery jobs exit_code char
 
 	# ------------------------------------------------------------------------------
 	# Sections

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -35,7 +35,7 @@ function __sf_section_docker -d "Display docker version and machine name"
     # if docker daemon isn't running you'll get an error like 'Bad response from Docker engine'
     [ -z docker_version ]; and return
 
-    if test $SPACEFISH_DOCKER_VERBOSE_VERSION = false
+    if test "$SPACEFISH_DOCKER_VERBOSE_VERSION" = "false"
         set docker_version (string split - $docker_version)[1]
     end
 

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -25,7 +25,11 @@ function __sf_section_docker -d "Display docker version and machine name"
     type -q docker; or return
 
     # Show docker version only when pwd has dockerfile or docker-compose.yml or COMPOSE_FILE
-    [ -f ./Dockerfile -o -f ./docker-compose.yml ]; or test "$COMPOSE_FILE"; or return
+	if not test -f Dockerfile \
+		-o -f docker-compose.yml \
+		-o -f $COMPOSE_FILE
+		return
+	end
 
     # Show Docker version only if docker deamon is up
     docker version > /dev/null 2>&1

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -31,7 +31,7 @@ function __sf_section_docker -d "Display docker version and machine name"
     docker ps > /dev/null 2>&1
     [ $status -ne 0 ]; and return
 
-    set -l docker_version v(docker version -f "{{.Server.Version}}" 2>/dev/null)
+    set -l docker_version v(docker version -f "{{.Server.Version}}" ^/dev/null)
     # if docker daemon isn't running you'll get an error like 'Bad response from Docker engine'
     [ -z docker_version ]; and return
 

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -21,14 +21,14 @@ function __sf_section_docker -d "Display docker version and machine name"
 
     [ $SPACEFISH_DOCKER_SHOW = false ]; and return
 
-    # Show docker version only when pwd has dockerfile or docker-compose.yml or COMPOSE_FILE
-    [ -f ./Dockerfile -o -f ./docker-compose.yml ]; or test "$COMPOSE_FILE"; or return
-
     # Show Docker version only if docker is installed
     type -q docker; or return
 
+    # Show docker version only when pwd has dockerfile or docker-compose.yml or COMPOSE_FILE
+    [ -f ./Dockerfile -o -f ./docker-compose.yml ]; or test "$COMPOSE_FILE"; or return
+
     # Show Docker version only if docker deamon is up
-    docker ps > /dev/null 2>&1
+    docker version > /dev/null 2>&1
     [ $status -ne 0 ]; and return
 
     set -l docker_version v(docker version -f "{{.Server.Version}}" ^/dev/null)

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -27,7 +27,7 @@ function __sf_section_docker -d "Display docker version and machine name"
     # Show Docker version only if docker is installed
     type -q docker; or return
 
-    set -l docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
+    set -l docker_version v(docker version -f "{{.Server.Version}}" 2>/dev/null)
     # if docker daemon isn't running you'll get an error like 'Bad response from Docker engine'
     [ -z docker_version ]; and return
 

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -27,6 +27,10 @@ function __sf_section_docker -d "Display docker version and machine name"
     # Show Docker version only if docker is installed
     type -q docker; or return
 
+    # Show Docker version only if docker deamon is up
+    docker ps > /dev/null 2>&1
+    [ $status -ne 0 ]; and return
+
     set -l docker_version v(docker version -f "{{.Server.Version}}" 2>/dev/null)
     # if docker daemon isn't running you'll get an error like 'Bad response from Docker engine'
     [ -z docker_version ]; and return
@@ -36,7 +40,7 @@ function __sf_section_docker -d "Display docker version and machine name"
     end
 
     if test -n "$DOCKER_MACHINE_NAME"
-        set docker_version docker_version via $DOCKER_MACHINE_NAME
+        set docker_version $docker_version via $DOCKER_MACHINE_NAME
     end
 
     __sf_lib_section \

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -27,7 +27,7 @@ function __sf_section_docker -d "Display docker version and machine name"
     # Show docker version only when pwd has dockerfile or docker-compose.yml or COMPOSE_FILE
 	if not test -f Dockerfile \
 		-o -f docker-compose.yml \
-		-o -f $COMPOSE_FILE
+		-o -f "$COMPOSE_FILE"
 		return
 	end
 

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -1,0 +1,47 @@
+#
+# Docker
+#
+# Current Docker version and Machine name.
+
+function __sf_section_docker -d "Display docker version and machine name"
+    # ------------------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------------------
+
+    __sf_util_set_default SPACEFISH_DOCKER_SHOW true
+    __sf_util_set_default SPACEFISH_DOCKER_PREFIX "is "
+    __sf_util_set_default SPACEFISH_DOCKER_SUFFIX $SPACEFISH_PROMPT_DEFAULT_SUFFIX
+    __sf_util_set_default SPACEFISH_DOCKER_SYMBOL "🐳 "
+    __sf_util_set_default SPACEFISH_DOCKER_COLOR cyan
+    __sf_util_set_default SPACEFISH_DOCKER_VERBOSE_VERSION false
+
+    # ------------------------------------------------------------------------------
+    # Section
+    # ------------------------------------------------------------------------------
+
+    [ $SPACEFISH_DOCKER_SHOW = false ]; and return
+
+    # Show docker version only when pwd has dockerfile or docker-compose.yml or COMPOSE_FILE
+    [ -f ./Dockerfile -o -f ./docker-compose.yml ]; or test "$COMPOSE_FILE"; or return
+
+    # Show Docker version only if docker is installed
+    type -q docker; or return
+
+    set -l docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
+    # if docker daemon isn't running you'll get an error like 'Bad response from Docker engine'
+    [ -z docker_version ]; and return
+
+    if test $SPACEFISH_DOCKER_VERBOSE_VERSION = false
+        set docker_version (string split - $docker_version)[1]
+    end
+
+    if test -n "$DOCKER_MACHINE_NAME"
+        set docker_version docker_version via $DOCKER_MACHINE_NAME
+    end
+
+    __sf_lib_section \
+		$SPACEFISH_DOCKER_COLOR \
+		$SPACEFISH_DOCKER_PREFIX \
+		"$SPACEFISH_DOCKER_SYMBOL$docker_version" \
+		$SPACEFISH_DOCKER_SUFFIX
+end

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -46,6 +46,6 @@ function __sf_section_docker -d "Display docker version and machine name"
     __sf_lib_section \
 		$SPACEFISH_DOCKER_COLOR \
 		$SPACEFISH_DOCKER_PREFIX \
-		"$SPACEFISH_DOCKER_SYMBOL$docker_version" \
+		"$SPACEFISH_DOCKER_SYMBOL""$docker_version" \
 		$SPACEFISH_DOCKER_SUFFIX
 end

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -31,13 +31,9 @@ function __sf_section_docker -d "Display docker version and machine name"
 		return
 	end
 
-    # Show Docker version only if docker deamon is up
-    docker version > /dev/null 2>&1
-    [ $status -ne 0 ]; and return
-
-    set -l docker_version v(docker version -f "{{.Server.Version}}" ^/dev/null)
+    set -l docker_version (docker version -f "{{.Server.Version}}" ^/dev/null)
     # if docker daemon isn't running you'll get an error like 'Bad response from Docker engine'
-    [ -z docker_version ]; and return
+    [ -z $docker_version ]; and return
 
     if test "$SPACEFISH_DOCKER_VERBOSE_VERSION" = "false"
         set docker_version (string split - $docker_version)[1]
@@ -50,6 +46,6 @@ function __sf_section_docker -d "Display docker version and machine name"
     __sf_lib_section \
 		$SPACEFISH_DOCKER_COLOR \
 		$SPACEFISH_DOCKER_PREFIX \
-		"$SPACEFISH_DOCKER_SYMBOL""$docker_version" \
+		"$SPACEFISH_DOCKER_SYMBOL""v$docker_version" \
 		$SPACEFISH_DOCKER_SUFFIX
 end

--- a/functions/__sf_section_docker.fish
+++ b/functions/__sf_section_docker.fish
@@ -46,6 +46,6 @@ function __sf_section_docker -d "Display docker version and machine name"
     __sf_lib_section \
 		$SPACEFISH_DOCKER_COLOR \
 		$SPACEFISH_DOCKER_PREFIX \
-		"$SPACEFISH_DOCKER_SYMBOL""v$docker_version" \
+		"$SPACEFISH_DOCKER_SYMBOL"v"$docker_version" \
 		$SPACEFISH_DOCKER_SUFFIX
 end

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -3,7 +3,7 @@ source $DIRNAME/mock.fish
 set -l LOCAL_DOCKER_VERSION 18.06.1
 
 function setup
-    spacefish_test_setup
+	spacefish_test_setup
 	mock docker 0 "echo \"18.06.1\""
 end
 

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -203,7 +203,7 @@ test "Doesn't display section when SPACEFISH_DOCKER_SHOW is set to 'false'"
 end
 
 test "Doesn't print section if docker is not installed"
-    (
+	(
 		touch Dockerfile
 		mock docker 127
 	) = (__sf_section_docker)

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -5,6 +5,8 @@ set -l LOCAL_DOCKER_VERSION 18.06.1
 function setup
 	spacefish_test_setup
 	mock docker 0 "echo \"18.06.1\""
+	mkdir -p /tmp/tmp-spacefish
+	cd /tmp/tmp-spacefish
 end
 
 function teardown

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -71,9 +71,10 @@ test "Prints section when both Dockerfile and docker-compose.yml are present"
 	) = (__sf_section_docker)
 end
 
-test "Prints Docker section when COMPOSE_FILE is set"
+test "Prints Docker section when COMPOSE_FILE is set and the $COMPOSE_FILE exists"
     (
-		set -g COMPOSE_FILE /path/to/some.file
+		set -g COMPOSE_FILE /tmp/some-compose-file.yml
+		touch /tmp/some-compose-file.yml
 
 		set_color --bold fff
 		echo -n "is "
@@ -89,6 +90,7 @@ end
 
 test "Prints section when only Dockerfile is present with DOCKER_MACHINE_NAME set"
 	(
+		rm /tmp/some-compose-file.yml
 		touch Dockerfile
 		set -g DOCKER_MACHINE_NAME some-machine-name
 
@@ -141,7 +143,8 @@ end
 
 test "Prints Docker section when COMPOSE_FILE is set with DOCKER_MACHINE_NAME set"
     (
-		set -g COMPOSE_FILE /path/to/some.file
+		set -g COMPOSE_FILE /tmp/some-compose-file.yml
+		touch /tmp/some-compose-file.yml
 		set -g DOCKER_MACHINE_NAME some-machine-name
 
 		set_color --bold fff
@@ -158,6 +161,7 @@ end
 
 test "Changing SPACEFISH_DOCKER_SYMBOL changes the displayed character"
 	(
+		rm /tmp/some-compose-file.yml
 		set SPACEFISH_DOCKER_SYMBOL "· "
 		touch Dockerfile
 

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -1,0 +1,217 @@
+source $DIRNAME/spacefish_test_setup.fish
+source $DIRNAME/mock.fish
+
+function setup
+    spacefish_test_setup
+    mock docker 0 "echo \"18.06.1\""
+end
+
+function teardown
+	if test -f Dockerfile
+		rm Dockerfile
+	end
+	if test -f docker-compose.yml
+		rm docker-compose.yml
+	end
+	if test "$COMPOSE_FILE"
+		set -e COMPOSE_FILE
+	end
+	if test "$DOCKER_MACHINE_NAME"
+		set -e DOCKER_MACHINE_NAME
+	end
+end
+
+test "Prints section when only Dockerfile is present"
+	(
+		touch Dockerfile
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Prints section when only docker-compose.yml is present"
+	(
+		touch docker-compose.yml
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Prints section when both Dockerfile and docker-compose.yml are present"
+	(
+		touch Dockerfile
+		touch docker-compose.yml
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Prints Docker section when COMPOSE_FILE is set"
+    (
+		set -g COMPOSE_FILE /path/to/some.file
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Prints section when only Dockerfile is present with $DOCKER_MACHINE_NAME set"
+	(
+		touch Dockerfile
+		set -g DOCKER_MACHINE_NAME some-machine-name
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1 via $DOCKER_MACHINE_NAME"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Prints section when only docker-compose.yml is present with $DOCKER_MACHINE_NAME set"
+	(
+		touch docker-compose.yml
+		set -g DOCKER_MACHINE_NAME some-machine-name
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1 via $DOCKER_MACHINE_NAME"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Prints section when both Dockerfile and docker-compose.yml are present with $DOCKER_MACHINE_NAME set"
+	(
+		touch Dockerfile
+		touch docker-compose.yml
+		set -g DOCKER_MACHINE_NAME some-machine-name
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1 via $DOCKER_MACHINE_NAME"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Prints Docker section when COMPOSE_FILE is set with $DOCKER_MACHINE_NAME set"
+    (
+		set -g COMPOSE_FILE /path/to/some.file
+		set -g DOCKER_MACHINE_NAME some-machine-name
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1 via $DOCKER_MACHINE_NAME"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Changing SPACEFISH_DOCKER_SYMBOL changes the displayed character"
+	(
+		set SPACEFISH_DOCKER_SYMBOL "· "
+		touch Dockerfile
+
+		set_color --bold fff
+		echo -n "is "
+		set_color normal
+		set_color --bold cyan
+		echo -n "· v18.06.1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+test "Changing SPACEFISH_DOCKER_PREFIX changes the character prefix"
+	(
+		set sf_exit_code 0
+		set SPACEFISH_DOCKER_PREFIX ·
+		touch Dockerfile
+
+		set_color --bold fff
+		echo -n "·"
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐳 v18.06.1"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
+	) = (__sf_section_docker)
+end
+
+
+# Negative
+test "Doesn't display section when SPACEFISH_DOCKER_SHOW is set to 'false'"
+	(
+		set SPACEFISH_DOCKER_SHOW false
+		touch Dockerfile
+
+	) = (__sf_section_docker)
+end
+
+test "Doesn't print section if docker is not installed"
+    (
+		touch Dockerfile
+		mock docker 127
+	) = (__sf_section_docker)
+end
+
+# This case can be checked only by bringing down the docker deamon
+test "Doesn't print section if docker deamon is not running"
+    () = (__sf_section_docker)
+end
+
+test "Doesn't print section when not in a directory with Dockerfile or docker-compose.yml"
+	() = (__sf_section_docker)
+end

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -10,12 +10,7 @@ function setup
 end
 
 function teardown
-	if test -f Dockerfile
-		rm Dockerfile
-	end
-	if test -f docker-compose.yml
-		rm docker-compose.yml
-	end
+	rm -rf /tmp/tmp-spacefish
 	if test "$COMPOSE_FILE"
 		set -e COMPOSE_FILE
 	end

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -1,9 +1,10 @@
 source $DIRNAME/spacefish_test_setup.fish
 source $DIRNAME/mock.fish
+set -l LOCAL_DOCKER_VERSION 18.06.1
 
 function setup
     spacefish_test_setup
-    mock docker 0 "echo \"18.06.1\""
+	mock docker 0 "echo \"18.06.1\""
 end
 
 function teardown
@@ -29,7 +30,7 @@ test "Prints section when only Dockerfile is present"
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -45,7 +46,7 @@ test "Prints section when only docker-compose.yml is present"
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -62,7 +63,7 @@ test "Prints section when both Dockerfile and docker-compose.yml are present"
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -78,7 +79,7 @@ test "Prints Docker section when COMPOSE_FILE is set"
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -86,7 +87,7 @@ test "Prints Docker section when COMPOSE_FILE is set"
 	) = (__sf_section_docker)
 end
 
-test "Prints section when only Dockerfile is present with $DOCKER_MACHINE_NAME set"
+test "Prints section when only Dockerfile is present with DOCKER_MACHINE_NAME set"
 	(
 		touch Dockerfile
 		set -g DOCKER_MACHINE_NAME some-machine-name
@@ -95,7 +96,7 @@ test "Prints section when only Dockerfile is present with $DOCKER_MACHINE_NAME s
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1 via $DOCKER_MACHINE_NAME"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION via $DOCKER_MACHINE_NAME"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -103,7 +104,7 @@ test "Prints section when only Dockerfile is present with $DOCKER_MACHINE_NAME s
 	) = (__sf_section_docker)
 end
 
-test "Prints section when only docker-compose.yml is present with $DOCKER_MACHINE_NAME set"
+test "Prints section when only docker-compose.yml is present with DOCKER_MACHINE_NAME set"
 	(
 		touch docker-compose.yml
 		set -g DOCKER_MACHINE_NAME some-machine-name
@@ -112,7 +113,7 @@ test "Prints section when only docker-compose.yml is present with $DOCKER_MACHIN
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1 via $DOCKER_MACHINE_NAME"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION via $DOCKER_MACHINE_NAME"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -120,7 +121,7 @@ test "Prints section when only docker-compose.yml is present with $DOCKER_MACHIN
 	) = (__sf_section_docker)
 end
 
-test "Prints section when both Dockerfile and docker-compose.yml are present with $DOCKER_MACHINE_NAME set"
+test "Prints section when both Dockerfile and docker-compose.yml are present with DOCKER_MACHINE_NAME set"
 	(
 		touch Dockerfile
 		touch docker-compose.yml
@@ -130,7 +131,7 @@ test "Prints section when both Dockerfile and docker-compose.yml are present wit
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1 via $DOCKER_MACHINE_NAME"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION via $DOCKER_MACHINE_NAME"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -138,7 +139,7 @@ test "Prints section when both Dockerfile and docker-compose.yml are present wit
 	) = (__sf_section_docker)
 end
 
-test "Prints Docker section when COMPOSE_FILE is set with $DOCKER_MACHINE_NAME set"
+test "Prints Docker section when COMPOSE_FILE is set with DOCKER_MACHINE_NAME set"
     (
 		set -g COMPOSE_FILE /path/to/some.file
 		set -g DOCKER_MACHINE_NAME some-machine-name
@@ -147,7 +148,7 @@ test "Prints Docker section when COMPOSE_FILE is set with $DOCKER_MACHINE_NAME s
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1 via $DOCKER_MACHINE_NAME"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION via $DOCKER_MACHINE_NAME"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -164,7 +165,7 @@ test "Changing SPACEFISH_DOCKER_SYMBOL changes the displayed character"
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
-		echo -n "· v18.06.1"
+		echo -n "· v$LOCAL_DOCKER_VERSION"
 		set_color normal
 		set_color --bold fff
 		echo -n " "
@@ -182,7 +183,7 @@ test "Changing SPACEFISH_DOCKER_PREFIX changes the character prefix"
 		echo -n "·"
 		set_color normal
 		set_color --bold cyan
-		echo -n "🐳 v18.06.1"
+		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
 		set_color --bold fff
 		echo -n " "


### PR DESCRIPTION
Implement Docker section based on the implementation on spaceship.

- Show docker version when current directory contains either of Dockerfile or docker-compose.yml
- Also show docker version when COMPOSE_FILE is set
- Write tests for new section
- Update documentation with the new section

## Motivation and Context
Closes #84 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):
<img width="596" alt="spacefish docker section" src="https://user-images.githubusercontent.com/11844760/47117438-f7836e00-d281-11e8-9690-9602257bcafb.png">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.