### PR TITLE
Add go modules (go.mod) to golang section detection

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -251,7 +251,7 @@ pyenv section is shown only in directories that contain `requirements.txt` or an
 
 ### Go \(`golang`\)
 
-Go section is shown only in directories that contain `Godeps`, `glide.yaml`, any other file with `.go` extension, or when current directory is in the Go workspace defined in `$GOPATH`.
+Go section is shown only in directories that contain `Godeps`, `glide.yaml`, `go.mod`, any other file with `.go` extension, or when current directory is in the Go workspace defined in `$GOPATH`.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/functions/__sf_section_golang.fish
+++ b/functions/__sf_section_golang.fish
@@ -26,7 +26,8 @@ function __sf_section_golang -d "Display the current go version if you're inside
 	# Ensure the go command is available
 	type -q go; or return
 
-	if not test -d Godeps \
+	if not test -f go.mod \
+		-o -d Godeps \
 		-o -f glide.yaml \
 		-o (count *.go) -gt 0 \
 		-o -f Gopkg.yml \

--- a/tests/__sf_section_golang.test.fish
+++ b/tests/__sf_section_golang.test.fish
@@ -4,7 +4,7 @@ source $DIRNAME/mock.fish
 function setup
 	spacefish_test_setup
 	mock go 0 "echo \"go version go1.10.3 darwin/amd64\""
-	mkdir -p /tmp/tmp-spacefish/Godeps
+	mkdir -p /tmp/tmp-spacefish
 	cd /tmp/tmp-spacefish
 end
 
@@ -14,6 +14,8 @@ end
 
 test "Prints section when Godeps is present"
 	(
+		mkdir /tmp/tmp-spacefish/Godeps
+
 		set_color --bold fff
 		echo -n "via "
 		set_color normal
@@ -28,7 +30,6 @@ end
 
 test "Prints section when glide.yaml is present"
 	(
-		rm -rf /tmp/tmp-spacefish/Godeps
 		touch /tmp/tmp-spacefish/glide.yaml
 
 		set_color --bold fff
@@ -45,7 +46,6 @@ end
 
 test "Prints section when Gopkg.yml is present"
 	(
-		rm -rf /tmp/tmp-spacefish/Godeps
 		touch /tmp/tmp-spacefish/Gopkg.yml
 
 		set_color --bold fff
@@ -62,7 +62,6 @@ end
 
 test "Prints section when Gopkg.lock is present"
 	(
-		rm -rf /tmp/tmp-spacefish/Godeps
 		touch /tmp/tmp-spacefish/Gopkg.lock
 
 		set_color --bold fff
@@ -77,14 +76,29 @@ test "Prints section when Gopkg.lock is present"
 	) = (__sf_section_golang)
 end
 
-test "Doesn't print the section when golang files aren't present"
+test "Prints section when go.mod is present"
 	(
-		rm -rf /tmp/tmp-spacefish/Godeps
+		touch /tmp/tmp-spacefish/go.mod
+
+		set_color --bold fff
+		echo -n "via "
+		set_color normal
+		set_color --bold cyan
+		echo -n "🐹 v1.10.3"
+		set_color normal
+		set_color --bold fff
+		echo -n " "
+		set_color normal
 	) = (__sf_section_golang)
+end
+
+test "Doesn't print the section when golang files aren't present"
+	() = (__sf_section_golang)
 end
 
 test "Changing SPACEFISH_GOLANG_SYMBOL changes the displayed character"
 	(
+		touch /tmp/tmp-spacefish/Gopkg.lock
 		set SPACEFISH_GOLANG_SYMBOL "· "
 
 		set_color --bold fff
@@ -101,6 +115,7 @@ end
 
 test "Changing SPACEFISH_GOLANG_PREFIX changes the character prefix"
 	(
+		touch /tmp/tmp-spacefish/Gopkg.lock
 		set sf_exit_code 0
 		set SPACEFISH_GOLANG_PREFIX ·
 
@@ -118,6 +133,7 @@ end
 
 test "Changing SPACEFISH_GOLANG_SUFFIX changes the character suffix"
 	(
+		touch /tmp/tmp-spacefish/Gopkg.lock
 		set sf_exit_code 0
 		set SPACEFISH_GOLANG_SUFFIX ·
 
@@ -135,6 +151,7 @@ end
 
 test "doesn't display the section when SPACEFISH_GOLANG_SHOW is set to \"false\""
 	(
+		touch /tmp/tmp-spacefish/Gopkg.lock
 		set SPACEFISH_GOLANG_SHOW false
 	) = (__sf_section_golang)
 end

--- a/tests/__sf_section_node.test.fish
+++ b/tests/__sf_section_node.test.fish
@@ -4,7 +4,7 @@ source $DIRNAME/mock.fish
 function setup
 	spacefish_test_setup
 	mock node 0 "echo \"v9.8.0\""
-	mkdir -p /tmp/tmp-spacefish/node_modules
+	mkdir -p /tmp/tmp-spacefish/
 	cd /tmp/tmp-spacefish
 end
 
@@ -14,6 +14,8 @@ end
 
 test "Prints section when node_modules is present"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
+
 		set_color --bold fff
 		echo -n "via "
 		set_color normal
@@ -28,7 +30,6 @@ end
 
 test "Prints section when package.json is present"
 	(
-		rm -rf /tmp/tmp-spacefish/node_modules
 		touch /tmp/tmp-spacefish/package.json
 
 		set_color --bold fff
@@ -44,13 +45,12 @@ test "Prints section when package.json is present"
 end
 
 test "Doesn't print section when not in a directory with node_modules or package.json"
-	(
-		rm -rf /tmp/tmp-spacefish/node_modules
-	) = (__sf_section_node)
+	() = (__sf_section_node)
 end
 
 test "Prints nvm version when nvm is installed"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		set -e sf_node_version
 		mock nvm 0 "echo \"v9.8.0\""
 
@@ -68,6 +68,7 @@ end
 
 test "Prints cached nvm version if previously used"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		set sf_node_version "v1.2.3"
 		set sf_last_nvm_bin "path_to_bin"
 		set NVM_BIN "path_to_bin"
@@ -87,6 +88,7 @@ end
 
 test "Prints nodenv version when nodenv is installed"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		mock nodenv 0 "echo \"v9.8.0\""
 
 		set_color --bold fff
@@ -102,24 +104,28 @@ test "Prints nodenv version when nodenv is installed"
 
 test "Prints nothing when using the \"system\" version of node with nvm"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		mock nvm 0 "echo \"system\""
 	) = (__sf_section_node)
 end
 
 test "Prints nothing when using the \"system\" version of node with nodenv"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		mock nodenv 0 "echo \"system\""
 	) = (__sf_section_node)
 end
 
 test "Prints nodenv version when nodenv is installed"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		mock nodenv 0 "echo \"node\""
 	) = (__sf_section_node)
 end
 
 test "Changing SPACEFISH_NODE_SYMBOL changes the displayed character"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		mock nvm 0 "echo \"v9.8.0\""
 		set SPACEFISH_NODE_SYMBOL "· "
 
@@ -137,6 +143,7 @@ end
 
 test "Changing SPACEFISH_NODE_PREFIX changes the character prefix"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		set sf_exit_code 0
 		set SPACEFISH_NODE_PREFIX ·
 
@@ -154,6 +161,7 @@ end
 
 test "Changing SPACEFISH_NODE_PREFIX changes the character prefix"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		set sf_exit_code 0
 		set SPACEFISH_NODE_SUFFIX ·
 
@@ -171,6 +179,7 @@ end
 
 test "Setting SPACEFISH_NODE_DEFAULT_VERSION to the current version disables the section"
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		set sf_exit_code 0
 		set SPACEFISH_NODE_DEFAULT_VERSION v9.8.0
 	) = (__sf_section_node)
@@ -178,6 +187,7 @@ end
 
 test "doesn't display the section when SPACEFISH_NODE_SHOW is set to \"false\""
 	(
+		mkdir /tmp/tmp-spacefish/node_modules
 		set SPACEFISH_NODE_SHOW false
 	) = (__sf_section_node)
 end

--- a/tests/__sf_section_php.test.fish
+++ b/tests/__sf_section_php.test.fish
@@ -7,7 +7,6 @@ function setup
 	Copyright (c) 1997-2018 The PHP Group
 	Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies\""
 	mkdir -p /tmp/tmp-spacefish
-	touch /tmp/tmp-spacefish/composer.json
 	cd /tmp/tmp-spacefish
 end
 
@@ -17,6 +16,8 @@ end
 
 test "Prints section when composer.json is present"
 	(
+		touch /tmp/tmp-spacefish/composer.json
+
 		set_color --bold fff
 		echo -n "via "
 		set_color normal
@@ -31,7 +32,6 @@ end
 
 test "Prints section when a *.php file is present"
 	(
-		rm -rf /tmp/tmp-spacefish/composer.json
 		touch /tmp/tmp-spacefish/testfile.php
 
 		set_color --bold fff
@@ -47,13 +47,12 @@ test "Prints section when a *.php file is present"
 end
 
 test "Doesn't print the section when composer.json and *.php aren't present"
-	(
-		rm -rf /tmp/tmp-spacefish/composer.json
-	) = (__sf_section_php)
+	() = (__sf_section_php)
 end
 
 test "Changing SPACEFISH_PHP_SYMBOL changes the displayed character"
 	(
+		touch /tmp/tmp-spacefish/composer.json
 		set SPACEFISH_PHP_SYMBOL "· "
 
 		set_color --bold fff
@@ -70,6 +69,7 @@ end
 
 test "Changing SPACEFISH_PHP_PREFIX changes the character prefix"
 	(
+		touch /tmp/tmp-spacefish/composer.json
 		set sf_exit_code 0
 		set SPACEFISH_PHP_PREFIX ·
 
@@ -87,6 +87,7 @@ end
 
 test "Changing SPACEFISH_PHP_SUFFIX changes the character suffix"
 	(
+		touch /tmp/tmp-spacefish/composer.json
 		set sf_exit_code 0
 		set SPACEFISH_PHP_SUFFIX ·
 
@@ -104,6 +105,7 @@ end
 
 test "doesn't display the section when SPACEFISH_PHP_SHOW is set to \"false\""
 	(
+		touch /tmp/tmp-spacefish/composer.json
 		set SPACEFISH_PHP_SHOW false
 	) = (__sf_section_php)
 end

--- a/tests/__sf_section_pyenv.test.fish
+++ b/tests/__sf_section_pyenv.test.fish
@@ -5,7 +5,6 @@ function setup
 	spacefish_test_setup
 	mock pyenv 0 "echo \"3.7.0\""
 	mkdir -p /tmp/tmp-spacefish
-	touch /tmp/tmp-spacefish/requirements.txt
 	cd /tmp/tmp-spacefish
 end
 
@@ -15,6 +14,8 @@ end
 
 test "Prints section when requirements.txt is present"
 	(
+		touch /tmp/tmp-spacefish/requirements.txt
+
 		set_color --bold fff
 		echo -n "via "
 		set_color normal
@@ -29,7 +30,6 @@ end
 
 test "Prints section when a *.py file is present"
 	(
-		rm -rf /tmp/tmp-spacefish/requirements.txt
 		touch /tmp/tmp-spacefish/testfile.py
 
 		set_color --bold fff
@@ -45,13 +45,12 @@ test "Prints section when a *.py file is present"
 end
 
 test "Doesn't print the section when requirements.txt and *.py aren't present"
-	(
-		rm -rf /tmp/tmp-spacefish/requirements.txt
-	) = (__sf_section_pyenv)
+	() = (__sf_section_pyenv)
 end
 
 test "Changing SPACEFISH_PYENV_SYMBOL changes the displayed character"
 	(
+		touch /tmp/tmp-spacefish/requirements.txt
 		set SPACEFISH_PYENV_SYMBOL "· "
 
 		set_color --bold fff
@@ -68,6 +67,7 @@ end
 
 test "Changing SPACEFISH_PYENV_PREFIX changes the character prefix"
 	(
+		touch /tmp/tmp-spacefish/requirements.txt
 		set sf_exit_code 0
 		set SPACEFISH_PYENV_PREFIX ·
 
@@ -85,6 +85,7 @@ end
 
 test "Changing SPACEFISH_PYENV_SUFFIX changes the character suffix"
 	(
+		touch /tmp/tmp-spacefish/requirements.txt
 		set sf_exit_code 0
 		set SPACEFISH_PYENV_SUFFIX ·
 
@@ -102,6 +103,7 @@ end
 
 test "doesn't display the section when SPACEFISH_PYENV_SHOW is set to \"false\""
 	(
+		touch /tmp/tmp-spacefish/requirements.txt
 		set SPACEFISH_PYENV_SHOW false
 	) = (__sf_section_pyenv)
 end

--- a/tests/__sf_section_rust.test.fish
+++ b/tests/__sf_section_rust.test.fish
@@ -5,7 +5,6 @@ function setup
 	spacefish_test_setup
 	mock rustc 0 "echo \"rustc 1.28.0-nightly (9634041f0 2018-07-30)\""
 	mkdir -p /tmp/tmp-spacefish
-	touch /tmp/tmp-spacefish/Cargo.toml
 	cd /tmp/tmp-spacefish
 end
 
@@ -15,6 +14,8 @@ end
 
 test "Prints section when Cargo.toml is present"
 	(
+		touch /tmp/tmp-spacefish/Cargo.toml
+
 		set_color --bold fff
 		echo -n "via "
 		set_color normal
@@ -29,7 +30,6 @@ end
 
 test "Prints section when a *.rs file is present"
 	(
-		rm -rf /tmp/tmp-spacefish/Cargo.toml
 		touch /tmp/tmp-spacefish/testfile.rs
 
 		set_color --bold fff
@@ -45,13 +45,12 @@ test "Prints section when a *.rs file is present"
 end
 
 test "Doesn't print the section when Cargo.toml and *.rs aren't present"
-	(
-		rm -rf /tmp/tmp-spacefish/Cargo.toml
-	) = (__sf_section_rust)
+	() = (__sf_section_rust)
 end
 
 test "Changing SPACEFISH_RUST_SYMBOL changes the displayed character"
 	(
+		touch /tmp/tmp-spacefish/Cargo.toml
 		set SPACEFISH_RUST_SYMBOL "· "
 
 		set_color --bold fff
@@ -68,6 +67,7 @@ end
 
 test "Changing SPACEFISH_RUST_PREFIX changes the character prefix"
 	(
+		touch /tmp/tmp-spacefish/Cargo.toml
 		set sf_exit_code 0
 		set SPACEFISH_RUST_PREFIX ·
 
@@ -85,6 +85,7 @@ end
 
 test "Changing SPACEFISH_RUST_SUFFIX changes the character suffix"
 	(
+		touch /tmp/tmp-spacefish/Cargo.toml
 		set sf_exit_code 0
 		set SPACEFISH_RUST_SUFFIX ·
 
@@ -102,8 +103,8 @@ end
 
 test "Prints verbose version when configured to do so"
 	(
-		touch /tmp/tmp-spacefish/testfile.rs
-        set SPACEFISH_RUST_VERBOSE_VERSION true
+		touch /tmp/tmp-spacefish/Cargo.toml
+		set SPACEFISH_RUST_VERBOSE_VERSION true
 
 		set_color --bold fff
 		echo -n "via "
@@ -119,6 +120,7 @@ end
 
 test "doesn't display the section when SPACEFISH_RUST_SHOW is set to \"false\""
 	(
+		touch /tmp/tmp-spacefish/Cargo.toml
 		set SPACEFISH_RUST_SHOW false
 	) = (__sf_section_rust)
 end

--- a/tests/run.fish
+++ b/tests/run.fish
@@ -10,6 +10,6 @@ if test ! -f $tmpDir/.config/fish/functions/fisher.fish
 end
 
 # Install fishtape and local spacefish into temp env
-env HOME=$tmpDir fish -c "fisher add fisherman/fishtape $gitRoot"
+env HOME=$tmpDir fish -c "fisher add jorgebucaran/fishtape $gitRoot"
 env HOME=$tmpDir fish -c "fish_prompt"
 env HOME=$tmpDir fish -c "fishtape $testDir/*.test.fish"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `go.mod` file to golang section detection.

Also happened to rework a few other tests as I wasn't happy with tests defaulting to sections being enabled by the dependant files being added in the setup step.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ports the following PR to spaceship: https://github.com/denysdovhan/spaceship-prompt/pull/559

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
