### PR TITLE
Redirect Battery Section to Null

### DIFF
--- a/functions/__sf_section_battery.fish
+++ b/functions/__sf_section_battery.fish
@@ -69,7 +69,7 @@ function __sf_section_battery -d "Displays battery symbol and charge"
 		set battery_status (echo $battery_data | grep state | awk '{print $2}')
 	# Windows machines.
 	else if type -q acpi
-		set -l battery_data (acpi -b)
+		set -l battery_data (acpi -b ^ /dev/null) # Redirect stderr to /dev/null fixes issue #110.
 
 		# Return if no battery
 		[ -z $battery_data ]; and return


### PR DESCRIPTION
## Description
Here's a quick port for the bugfix from upstream! From looking at documentation, it appears the "correct" way to redirect stderr in Fish is to use the `^` caret symbol. :slightly_smiling_face: 

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #110.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
