### PR TITLE
Hide kubecontext outside of kube project

### DIFF
--- a/fish_mode_prompt.fish
+++ b/fish_mode_prompt.fish
@@ -1,4 +1,4 @@
 function fish_mode_prompt
-    # Overriden by Spacefish fishshell theme
-    # To see vi mode in prompt add 'vi_mode' to SPACEFISH_PROMPT_ORDER
+	# Overriden by Spacefish fishshell theme
+	# To see vi mode in prompt add 'vi_mode' to SPACEFISH_PROMPT_ORDER
 end

--- a/functions/__sf_section_kubecontext.fish
+++ b/functions/__sf_section_kubecontext.fish
@@ -29,6 +29,7 @@ function __sf_section_kubecontext -d "Display the kubernetes context"
 	type -q kubectl; or return
 
 	set -l kube_context (kubectl config current-context ^/dev/null)
+	[ -z $kube_context ]; and return
 
 	__sf_lib_section \
 		$SPACEFISH_KUBECONTEXT_COLOR \

--- a/functions/__sf_section_kubecontext.fish
+++ b/functions/__sf_section_kubecontext.fish
@@ -12,7 +12,7 @@ function __sf_section_kubecontext -d "Display the kubernetes context"
 
 	__sf_util_set_default SPACEFISH_KUBECONTEXT_SHOW true
 	__sf_util_set_default SPACEFISH_KUBECONTEXT_PREFIX "at "
-  __sf_util_set_default SPACEFISH_KUBECONTEXT_SUFFIX $SPACEFISH_PROMPT_DEFAULT_SUFFIX
+	__sf_util_set_default SPACEFISH_KUBECONTEXT_SUFFIX $SPACEFISH_PROMPT_DEFAULT_SUFFIX
 	# Additional space is added because ☸️ is wider than other symbols
 	# See: https://github.com/denysdovhan/spaceship-prompt/pull/432
 	__sf_util_set_default SPACEFISH_KUBECONTEXT_SYMBOL "☸️  "

--- a/tests/__sf_section_conda.test.fish
+++ b/tests/__sf_section_conda.test.fish
@@ -3,17 +3,17 @@ source $DIRNAME/mock.fish
 set -l LOCAL_CONDA_VERSION 4.5.11
 
 function setup
-    spacefish_test_setup
-    mock conda 0 "echo \"conda 4.5.11\""
-    mkdir -p /tmp/tmp-spacefish
-    cd /tmp/tmp-spacefish
+	spacefish_test_setup
+	mock conda 0 "echo \"conda 4.5.11\""
+	mkdir -p /tmp/tmp-spacefish
+	cd /tmp/tmp-spacefish
 end
 
 function teardown
-    rm -rf /tmp/tmp-spacefish
-    if test "$CONDA_DEFAULT_ENV"
-        set -e CONDA_DEFAULT_ENV
-    end
+	rm -rf /tmp/tmp-spacefish
+	if test "$CONDA_DEFAULT_ENV"
+		set -e CONDA_DEFAULT_ENV
+	end
 end
 
 test "Prints section when conda is installed and CONDA_DEFAULT_ENV is set"

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -69,7 +69,7 @@ test "Prints section when both Dockerfile and docker-compose.yml are present"
 end
 
 test "Prints Docker section when COMPOSE_FILE is set and the $COMPOSE_FILE exists"
-    (
+	(
 		set -g COMPOSE_FILE /tmp/some-compose-file.yml
 		touch /tmp/some-compose-file.yml
 
@@ -139,7 +139,7 @@ test "Prints section when both Dockerfile and docker-compose.yml are present wit
 end
 
 test "Prints Docker section when COMPOSE_FILE is set with DOCKER_MACHINE_NAME set"
-    (
+		(
 		set -g COMPOSE_FILE /tmp/some-compose-file.yml
 		touch /tmp/some-compose-file.yml
 		set -g DOCKER_MACHINE_NAME some-machine-name
@@ -211,7 +211,7 @@ end
 
 # This case can be checked only by bringing down the docker deamon
 test "Doesn't print section if docker deamon is not running"
-    () = (__sf_section_docker)
+		() = (__sf_section_docker)
 end
 
 test "Doesn't print section when not in a directory with Dockerfile or docker-compose.yml"

--- a/tests/__sf_section_host.test.fish
+++ b/tests/__sf_section_host.test.fish
@@ -90,8 +90,8 @@ end
 # Color testing; magenta = pass, red = failure.
 test "Test color, no SSH."
 	(
-		set SPACEFISH_HOST_COLOR  "magenta" # No SSH connection. This should display.
-		set SPACEFISH_HOST_COLOR_SSH  "red" # If red shows, test failed.
+		set SPACEFISH_HOST_COLOR "magenta" # No SSH connection. This should display.
+		set SPACEFISH_HOST_COLOR_SSH "red" # If red shows, test failed.
 		set SPACEFISH_HOST_SHOW always
 
 		set_color --bold fff
@@ -108,8 +108,8 @@ end
 
 test "Test color, with SSH."
 	(
-		set SPACEFISH_HOST_COLOR  "red" # If red shows, test failed.
-		set SPACEFISH_HOST_COLOR_SSH  "magenta" # SSH connection exists. This should take precedence.
+		set SPACEFISH_HOST_COLOR "red" # If red shows, test failed.
+		set SPACEFISH_HOST_COLOR_SSH "magenta" # SSH connection exists. This should take precedence.
 		set SSH_CONNECTION "192.168.0.100 12345 192.168.0.101 22"
 
 		set_color --bold fff

--- a/tests/__sf_section_kubecontext.test.fish
+++ b/tests/__sf_section_kubecontext.test.fish
@@ -20,6 +20,12 @@ test "Prints section"
 	) = (__sf_section_kubecontext)
 end
 
+test "Kubecontext symbol does not appear outside of a Kubernetes project"
+	(
+		mock kubectl 1
+	) = (__sf_section_kubecontext)
+end
+
 test "Changing SPACEFISH_KUBECONTEXT_SYMBOL changes the displayed character"
 	(
 		set SPACEFISH_KUBECONTEXT_SYMBOL "· "

--- a/tests/__sf_util_git_branch.test.fish
+++ b/tests/__sf_util_git_branch.test.fish
@@ -40,7 +40,7 @@ test "Identifies an alternate branch name"
 end
 
 test "No result provided for non-git directory"
-    '' = (
+	'' = (
 		__sf_util_git_branch
 	)
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an early return when `kube_context` is not present.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #111 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
