### PR TITLE
Remove color from prefix/suffix

### DIFF
--- a/functions/__sf_lib_section.fish
+++ b/functions/__sf_lib_section.fish
@@ -21,7 +21,7 @@ function __sf_lib_section -a color prefix content suffix
 
 	if test "$SPACEFISH_PROMPT_SUFFIXES_SHOW" = "true"
 		# Echo suffixes in bold white
-		set_color --bold fff
+		set_color --bold
 		echo -e -n -s $suffix
 		set_color normal
 	end

--- a/functions/__sf_lib_section.fish
+++ b/functions/__sf_lib_section.fish
@@ -7,7 +7,7 @@ function __sf_lib_section -a color prefix content suffix
 
 	if test "$sf_prompt_opened" = "true" -a "$SPACEFISH_PROMPT_PREFIXES_SHOW" = "true"
 		# Echo prefixes in bold white
-		set_color --bold fff
+		set_color --bold
 		echo -e -n -s $prefix
 		set_color normal
 	end

--- a/functions/__sf_section_dir.fish
+++ b/functions/__sf_section_dir.fish
@@ -43,7 +43,7 @@ function __sf_section_dir -d "Display the current truncated directory"
 	set dir (__sf_util_truncate_dir $tmp $SPACEFISH_DIR_TRUNC)
 
 	if [ $SPACEFISH_DIR_LOCK_SHOW = true -a ! -w . ]
-		set DIR_LOCK_SYMBOL (set_color $SPACEFISH_DIR_LOCK_COLOR)" $SPACEFISH_DIR_LOCK_SYMBOL"(set_color --bold fff)
+		set DIR_LOCK_SYMBOL (set_color $SPACEFISH_DIR_LOCK_COLOR)" $SPACEFISH_DIR_LOCK_SYMBOL"(set_color --bold)
 	end
 
 	__sf_lib_section \

--- a/tests/__sf_lib_section.test.fish
+++ b/tests/__sf_lib_section.test.fish
@@ -6,13 +6,13 @@ end
 
 test "Displays only the colored content when 2 arguments are passed"
 	(
-		set_color --bold fff
+		set_color --bold
 		echo -n ""
 		set_color normal
 		set_color --bold red
 		echo -n "test content"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n ""
 		set_color normal
 	) = (__sf_lib_section red "test content")
@@ -20,13 +20,13 @@ end
 
 test "Displays the prefix, colored content and suffix when 4 arguments are passed"
 	(
-		set_color --bold fff
+		set_color --bold
 		echo -n "prefix"
 		set_color normal
 		set_color --bold red
 		echo -n "test content"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "suffix"
 		set_color normal
 	) = (__sf_lib_section red prefix "test content" suffix)
@@ -36,13 +36,13 @@ test "Displays the prefix if prefixes are enabled"
 	(
 		set SPACEFISH_PROMPT_PREFIXES_SHOW true
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "prefix"
 		set_color normal
 		set_color --bold red
 		echo -n "test content"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "suffix"
 		set_color normal
 	) = (__sf_lib_section red prefix "test content" suffix)
@@ -55,7 +55,7 @@ test "Doesn't display the prefix if prefixes are disabled"
 		set_color --bold red
 		echo -n "test content"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "suffix"
 		set_color normal
 	) = (__sf_lib_section red prefix "test content" suffix)
@@ -65,13 +65,13 @@ test "Displays the suffix if suffixes are enabled"
 	(
 		set SPACEFISH_PROMPT_SUFFIXES_SHOW true
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "prefix"
 		set_color normal
 		set_color --bold red
 		echo -n "test content"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "suffix"
 		set_color normal
 	) = (__sf_lib_section red prefix "test content" suffix)
@@ -81,7 +81,7 @@ test "Doesn't display the suffix if suffixes are disabled"
 	(
 		set SPACEFISH_PROMPT_SUFFIXES_SHOW false
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "prefix"
 		set_color normal
 		set_color --bold red
@@ -97,17 +97,17 @@ test "Only prints the prefix for the second consecutive section"
 		set_color --bold red
 		echo -n "test content 1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "suffix 1"
 		set_color normal
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "prefix 2"
 		set_color normal
 		set_color --bold red
 		echo -n "test content 2"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "suffix 2"
 		set_color normal
 	) = (

--- a/tests/__sf_section_aws.test.fish
+++ b/tests/__sf_section_aws.test.fish
@@ -9,13 +9,13 @@ end
 
 test "Prints section when AWS_PROFILE is set"
 	(
-		set_color --bold fff
+		set_color --bold
 		echo -n "using "
 		set_color normal
 		set_color --bold ff8700
 		echo -n "☁️ user1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_aws)
@@ -37,13 +37,13 @@ test "Changing SPACEFISH_AWS_SYMBOL changes the displayed character"
 	(
 		set SPACEFISH_AWS_SYMBOL "· "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "using "
 		set_color normal
 		set_color --bold ff8700
 		echo -n "· user1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_aws)
@@ -54,13 +54,13 @@ test "Changing SPACEFISH_AWS_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_AWS_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold ff8700
 		echo -n "☁️ user1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_aws)
@@ -71,13 +71,13 @@ test "Changing SPACEFISH_AWS_SUFFIX changes the character suffix"
 		set sf_exit_code 0
 		set SPACEFISH_AWS_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "using "
 		set_color normal
 		set_color --bold ff8700
 		echo -n "☁️ user1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_aws)

--- a/tests/__sf_section_char.test.fish
+++ b/tests/__sf_section_char.test.fish
@@ -8,13 +8,13 @@ test "Displays default char with status code 0"
 	(
 		set sf_exit_code 0
 
-		set_color --bold fff
+		set_color --bold
 		echo -n ""
 		set_color normal
 		set_color --bold green
 		echo -n "➜"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_char)
@@ -24,13 +24,13 @@ test "Displays default char with status code 1"
 	(
 		set sf_exit_code 1
 
-		set_color --bold fff
+		set_color --bold
 		echo -n ""
 		set_color normal
 		set_color --bold red
 		echo -n "➜"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_char)
@@ -41,13 +41,13 @@ test "Changing SPACEFISH_CHAR_SYMBOL changes the displayed character"
 		set sf_exit_code 0
 		set SPACEFISH_CHAR_SYMBOL ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n ""
 		set_color normal
 		set_color --bold green
 		echo -n "·"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_char)
@@ -58,13 +58,13 @@ test "Changing SPACEFISH_CHAR_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_CHAR_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold green
 		echo -n "➜"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_char)
@@ -75,13 +75,13 @@ test "Changing SPACEFISH_CHAR_SYMBOL changes the character suffix"
 		set sf_exit_code 0
 		set SPACEFISH_CHAR_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n ""
 		set_color normal
 		set_color --bold green
 		echo -n "➜"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_char)

--- a/tests/__sf_section_conda.test.fish
+++ b/tests/__sf_section_conda.test.fish
@@ -20,13 +20,13 @@ test "Prints section when conda is installed and CONDA_DEFAULT_ENV is set"
 	(
 		set -g CONDA_DEFAULT_ENV some-env
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold blue
 		echo -n "🅒 v$LOCAL_CONDA_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_conda)
@@ -37,13 +37,13 @@ test "Changing SPACEFISH_CONDA_SYMBOL changes the displayed character"
 		set SPACEFISH_CONDA_SYMBOL "· "
 		set -g CONDA_DEFAULT_ENV some-env
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold blue
 		echo -n "· v$LOCAL_CONDA_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_conda)
@@ -54,13 +54,13 @@ test "Changing SPACEFISH_CONDA_PREFIX changes the character prefix"
 		set SPACEFISH_CONDA_PREFIX ·
 		set -g CONDA_DEFAULT_ENV some-env
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold blue
 		echo -n "🅒 v$LOCAL_CONDA_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_conda)

--- a/tests/__sf_section_dir.test.fish
+++ b/tests/__sf_section_dir.test.fish
@@ -23,13 +23,13 @@ test "Correctly truncates home directory"
 	(
 		cd ~
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "~"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -39,13 +39,13 @@ test "Correctly truncates a home subdirectory"
 	(
 		cd ~/.tmp-spacefish/dir1/
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "~/.tmp-spacefish/dir1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -55,13 +55,13 @@ test "Correctly truncates a deeply nested home subdirectory"
 	(
 		cd ~/.tmp-spacefish/dir1/dir2
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n ".tmp-spacefish/dir1/dir2"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -75,13 +75,13 @@ test "Correctly truncates root directory"
 	(
 		cd /
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "/"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -91,13 +91,13 @@ test "Correctly truncates a root subdirectory"
 	(
 		cd /usr
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "/usr"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -107,13 +107,13 @@ test "Correctly truncates a deeply nested root subdirectory"
 	(
 		cd /tmp/tmp-spacefish/dir1/dir2
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "tmp-spacefish/dir1/dir2"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -128,13 +128,13 @@ test "Correctly truncates the root of a git directory"
 		cd /tmp/tmp-spacefish
 		command git init >/dev/null
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "tmp-spacefish"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -146,13 +146,13 @@ test "Correctly truncates a git subdirectory"
 		command git init >/dev/null
 		cd /tmp/tmp-spacefish/dir1
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "tmp-spacefish/dir1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -164,13 +164,13 @@ test "Correctly truncates a deeply nested git subdirectory"
 		command git init >/dev/null
 		cd /tmp/tmp-spacefish/dir1/dir2/dir3
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "dir1/dir2/dir3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -184,13 +184,13 @@ test "Correctly truncates the root of a git directory within another"
 		cd /tmp/tmp-spacefish/dir1
 		command git init >/dev/null
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "dir1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -203,13 +203,13 @@ test "Doesn't throw an error when in a .git directory"
 
 		cd /tmp/tmp-spacefish/.git
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "tmp/tmp-spacefish/.git"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -229,13 +229,13 @@ test "Changing SPACEFISH_DIR_PREFIX changes the dir prefix"
 		set SPACEFISH_DIR_PREFIX ·
 		cd ~
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold cyan
 		echo -n "~"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -246,13 +246,13 @@ test "Changing SPACEFISH_DIR_SUFFIX changes the dir prefix"
 		set SPACEFISH_DIR_SUFFIX ·
 		cd ~
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "~"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_dir)
@@ -265,13 +265,13 @@ test "Changing SPACEFISH_DIR_TRUNC changes the dir length"
 		set SPACEFISH_DIR_TRUNC 1
 		cd /tmp/tmp-spacefish/dir1/dir2/dir3
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "dir3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -283,13 +283,13 @@ test "Disabling SPACEFISH_DIR_TRUNC_REPO stops repo dir truncation"
 		cd ~/.tmp-spacefish
 		command git init >/dev/null
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "~/.tmp-spacefish"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -300,13 +300,13 @@ test "Changing SPACEFISH_DIR_COLOR changes the dir color"
 		set SPACEFISH_DIR_COLOR red
 		cd ~
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold red
 		echo -n "~"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -321,13 +321,13 @@ test "Shows DIR_LOCK_SYMBOL if in a dir with no write permissions and SPACEFISH_
 	(
 		cd /tmp/tmp-spacefish/writeProtected
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "tmp/tmp-spacefish/writeProtected"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -337,13 +337,13 @@ test "Doesn't show DIR_LOCK_SYMBOL if SPACEFISH_DIR_LOCK_SHOW is false"
 	(
 		cd /tmp/tmp-spacefish/writeProtected
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "tmp/tmp-spacefish/writeProtected"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -353,13 +353,13 @@ test "Doesn't show DIR_LOCK_SYMBOL if current directory is not write protected f
 	(
 		cd ~
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "~"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)
@@ -370,13 +370,13 @@ test "Changing SPACEFISH_DIR_LOCK_SYMBOL changes the symbol"
 		set SPACEFISH_DIR_LOCK_SYMBOL "😀"
 		cd /tmp/tmp-spacefish/writeProtected
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "in "
 		set_color normal
 		set_color --bold cyan
 		echo -n "tmp/tmp-spacefish/writeProtected"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dir)

--- a/tests/__sf_section_docker.test.fish
+++ b/tests/__sf_section_docker.test.fish
@@ -23,13 +23,13 @@ test "Prints section when only Dockerfile is present"
 	(
 		touch Dockerfile
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -39,13 +39,13 @@ test "Prints section when only docker-compose.yml is present"
 	(
 		touch docker-compose.yml
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -56,13 +56,13 @@ test "Prints section when both Dockerfile and docker-compose.yml are present"
 		touch Dockerfile
 		touch docker-compose.yml
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -73,13 +73,13 @@ test "Prints Docker section when COMPOSE_FILE is set and the $COMPOSE_FILE exist
 		set -g COMPOSE_FILE /tmp/some-compose-file.yml
 		touch /tmp/some-compose-file.yml
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -91,13 +91,13 @@ test "Prints section when only Dockerfile is present with DOCKER_MACHINE_NAME se
 		touch Dockerfile
 		set -g DOCKER_MACHINE_NAME some-machine-name
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION via $DOCKER_MACHINE_NAME"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -108,13 +108,13 @@ test "Prints section when only docker-compose.yml is present with DOCKER_MACHINE
 		touch docker-compose.yml
 		set -g DOCKER_MACHINE_NAME some-machine-name
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION via $DOCKER_MACHINE_NAME"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -126,13 +126,13 @@ test "Prints section when both Dockerfile and docker-compose.yml are present wit
 		touch docker-compose.yml
 		set -g DOCKER_MACHINE_NAME some-machine-name
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION via $DOCKER_MACHINE_NAME"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -144,13 +144,13 @@ test "Prints Docker section when COMPOSE_FILE is set with DOCKER_MACHINE_NAME se
 		touch /tmp/some-compose-file.yml
 		set -g DOCKER_MACHINE_NAME some-machine-name
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION via $DOCKER_MACHINE_NAME"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -162,13 +162,13 @@ test "Changing SPACEFISH_DOCKER_SYMBOL changes the displayed character"
 		set SPACEFISH_DOCKER_SYMBOL "· "
 		touch Dockerfile
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold cyan
 		echo -n "· v$LOCAL_DOCKER_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)
@@ -180,13 +180,13 @@ test "Changing SPACEFISH_DOCKER_PREFIX changes the character prefix"
 		set SPACEFISH_DOCKER_PREFIX ·
 		touch Dockerfile
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐳 v$LOCAL_DOCKER_VERSION"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_docker)

--- a/tests/__sf_section_dotnet.test.fish
+++ b/tests/__sf_section_dotnet.test.fish
@@ -26,13 +26,13 @@ test "Prints section if project.json is present"
 	(
 		touch /tmp/tmp-spacefish/project.json
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold af00d7
 		echo -n ".NET 2.1.403"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dotnet)
@@ -41,14 +41,14 @@ end
 test "Prints section if global.json is present"
 	(
 		touch /tmp/tmp-spacefish/global.json
-		set_color --bold fff
+		set_color --bold
 
 		echo -n "via "
 		set_color normal
 		set_color --bold af00d7
 		echo -n ".NET 2.1.403"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dotnet)
@@ -58,13 +58,13 @@ test "Prints section if a .csproj file is present"
 	(
 		touch /tmp/tmp-spacefish/tmp.csproj
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold af00d7
 		echo -n ".NET 2.1.403"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dotnet)
@@ -73,14 +73,14 @@ end
 test "Prints section if a .xproj file is present"
 	(
 		touch /tmp/tmp-spacefish/tmp.xproj
-		set_color --bold fff
+		set_color --bold
 
 		echo -n "via "
 		set_color normal
 		set_color --bold af00d7
 		echo -n ".NET 2.1.403"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dotnet)
@@ -90,13 +90,13 @@ test "Prints section if a .sln file is present"
 	(
 		touch /tmp/tmp-spacefish/tmp.sln
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold af00d7
 		echo -n ".NET 2.1.403"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dotnet)
@@ -107,13 +107,13 @@ test "Changing SPACEFISH_DOTNET_SYMBOL changes the displayed character"
 		touch /tmp/tmp-spacefish/tmp.sln
 
 		set SPACEFISH_DOTNET_SYMBOL "· "
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold af00d7
 		echo -n "· 2.1.403"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dotnet)
@@ -125,13 +125,13 @@ test "Changing SPACEFISH_DOTNET_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_DOTNET_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold af00d7
 		echo -n ".NET 2.1.403"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_dotnet)
@@ -143,13 +143,13 @@ test "Changing SPACEFISH_DOTNET_SUFFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_DOTNET_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold af00d7
 		echo -n ".NET 2.1.403"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_dotnet)

--- a/tests/__sf_section_exit_code.test.fish
+++ b/tests/__sf_section_exit_code.test.fish
@@ -15,12 +15,12 @@ test "Enable exit-code, shows exit code upon fail"
 		set SPACEFISH_EXIT_CODE_SHOW true
 		set sf_exit_code 1
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold red
 		echo -n "✘1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_exit_code)
@@ -39,12 +39,12 @@ test "Color-changing exit code"
 		set SPACEFISH_EXIT_CODE_COLOR "purple"
 		set sf_exit_code 1
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold purple
 		echo -n "✘1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_exit_code)

--- a/tests/__sf_section_git_status.test.fish
+++ b/tests/__sf_section_git_status.test.fish
@@ -21,12 +21,12 @@ test "Displays the correct symbol for untracked file"
 	(
 		touch testfile
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold red
 		echo -n " [?]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 	) = (__sf_section_git_status)
 end
@@ -36,12 +36,12 @@ test "Displays the correct symbol for added file"
 		touch testfile
 		command git add testfile
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold red
 		echo -n " [+]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 	) = (__sf_section_git_status)
 end
@@ -53,12 +53,12 @@ test "Displays the correct symbol for modified file"
 		command git commit -m "Initial commit" --quiet
 		echo "modification" > testfile
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold red
 		echo -n " [!]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 	) = (__sf_section_git_status)
 end
@@ -71,12 +71,12 @@ test "Displays the correct symbol for renamed file"
 		mv testfile newtestfile
 		command git add testfile newtestfile
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold red
 		echo -n " [»]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 	) = (__sf_section_git_status)
 end
@@ -89,12 +89,12 @@ test "Displays the correct symbol for deleted file"
 		rm testfile
 		command git add testfile
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold red
 		echo -n " [✘]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 	) = (__sf_section_git_status)
 end
@@ -107,12 +107,12 @@ test "Displays the correct symbol for stashed file"
 		echo "modification" > testfile
 		command git stash --quiet
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold red
 		echo -n " [\$]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 	) = (__sf_section_git_status)
 end

--- a/tests/__sf_section_golang.test.fish
+++ b/tests/__sf_section_golang.test.fish
@@ -16,13 +16,13 @@ test "Prints section when Godeps is present"
 	(
 		mkdir /tmp/tmp-spacefish/Godeps
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐹 v1.10.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_golang)
@@ -32,13 +32,13 @@ test "Prints section when glide.yaml is present"
 	(
 		touch /tmp/tmp-spacefish/glide.yaml
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐹 v1.10.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_golang)
@@ -48,13 +48,13 @@ test "Prints section when Gopkg.yml is present"
 	(
 		touch /tmp/tmp-spacefish/Gopkg.yml
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐹 v1.10.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_golang)
@@ -64,13 +64,13 @@ test "Prints section when Gopkg.lock is present"
 	(
 		touch /tmp/tmp-spacefish/Gopkg.lock
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐹 v1.10.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_golang)
@@ -80,13 +80,13 @@ test "Prints section when go.mod is present"
 	(
 		touch /tmp/tmp-spacefish/go.mod
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐹 v1.10.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_golang)
@@ -101,13 +101,13 @@ test "Changing SPACEFISH_GOLANG_SYMBOL changes the displayed character"
 		touch /tmp/tmp-spacefish/Gopkg.lock
 		set SPACEFISH_GOLANG_SYMBOL "· "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold cyan
 		echo -n "· v1.10.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_golang)
@@ -119,13 +119,13 @@ test "Changing SPACEFISH_GOLANG_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_GOLANG_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐹 v1.10.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_golang)
@@ -137,13 +137,13 @@ test "Changing SPACEFISH_GOLANG_SUFFIX changes the character suffix"
 		set sf_exit_code 0
 		set SPACEFISH_GOLANG_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold cyan
 		echo -n "🐹 v1.10.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_golang)

--- a/tests/__sf_section_host.test.fish
+++ b/tests/__sf_section_host.test.fish
@@ -15,13 +15,13 @@ test "Correctly shows hostname upon SSH connection"
 	(
 		set SSH_CONNECTION "192.168.0.100 12345 192.168.0.101 22"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold green
 		echo -n (hostname)
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_host)
@@ -31,13 +31,13 @@ test "Displays user when SPACEFISH_HOST_SHOW is set to \"always\""
 	(
 		set SPACEFISH_HOST_SHOW always
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold blue
 		echo -n (hostname)
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_host)
@@ -48,13 +48,13 @@ test "Displays user when SPACEFISH_HOST_SHOW is set to \"always\", over SSH"
 		set SPACEFISH_HOST_SHOW always
 		set SSH_CONNECTION "192.168.0.100 12345 192.168.0.101 22"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold green
 		echo -n (hostname)
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_host)
@@ -71,13 +71,13 @@ test "Displays hostname when set different from machine name, over SSH"
 		mock hostname \* 0 "echo \"spacefish\""
 		set SSH_CONNECTION "192.168.0.100 12345 192.168.0.101 22"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold green
 		echo -n "spacefish"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_host)
@@ -94,13 +94,13 @@ test "Test color, no SSH."
 		set SPACEFISH_HOST_COLOR_SSH "red" # If red shows, test failed.
 		set SPACEFISH_HOST_SHOW always
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold "magenta"
 		echo -n (hostname)
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_host)
@@ -112,13 +112,13 @@ test "Test color, with SSH."
 		set SPACEFISH_HOST_COLOR_SSH "magenta" # SSH connection exists. This should take precedence.
 		set SSH_CONNECTION "192.168.0.100 12345 192.168.0.101 22"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold "magenta"
 		echo -n (hostname)
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_host)

--- a/tests/__sf_section_jobs.test.fish
+++ b/tests/__sf_section_jobs.test.fish
@@ -13,12 +13,12 @@ test "Test a single background job"
 	(
 		sleep 5 & # Background process
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold blue
 		echo -n "✦"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_jobs)
@@ -29,12 +29,12 @@ test "Test with two background jobs"
 		sleep 5 & # Background process #1
 		sleep 5 & # Background process #2
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold blue
 		echo -n "✦2"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_jobs)
@@ -48,12 +48,12 @@ test "Test with five background jobs"
 		sleep 5 & # Background process #4
 		sleep 5 & # Background process #5
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold blue
 		echo -n "✦5"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_jobs)
@@ -67,12 +67,12 @@ test "Test with less than threshold of background jobs"
 		sleep 5 & # Background process #2
 		sleep 5 & # Background process #3
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold blue
 		echo -n "✦"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_jobs)
@@ -87,12 +87,12 @@ test "Test with equal threshold of background jobs"
 		sleep 5 & # Background process #3
 		sleep 5 & # Background process #4
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold blue
 		echo -n "✦"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_jobs)
@@ -109,12 +109,12 @@ test "Test with more than threshold of background jobs"
 		sleep 5 & # Background process #5
 		sleep 5 & # Background process #6
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold blue
 		echo -n "✦6"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_jobs)

--- a/tests/__sf_section_julia.test.fish
+++ b/tests/__sf_section_julia.test.fish
@@ -16,13 +16,13 @@ test "Prints section when julia is installed and pwd has *.jl file(s)"
 	(
 		touch some-julia-file.jl
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold green
 		echo -n "ஃ v1.0.1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_julia)
@@ -33,13 +33,13 @@ test "Changing SPACEFISH_JULIA_SYMBOL changes the displayed character"
 		set SPACEFISH_JULIA_SYMBOL "· "
 		touch some-julia-file.jl
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold green
 		echo -n "· v1.0.1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_julia)
@@ -50,13 +50,13 @@ test "Changing SPACEFISH_JULIA_PREFIX changes the character prefix"
 		set SPACEFISH_JULIA_PREFIX ·
 		touch some-julia-file.jl
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold green
 		echo -n "ஃ v1.0.1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_julia)
@@ -67,13 +67,13 @@ test "Changing SPACEFISH_JULIA_SUFFIX changes the character suffix"
 		set SPACEFISH_JULIA_SUFFIX ·
 		touch some-julia-file.jl
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "is "
 		set_color normal
 		set_color --bold green
 		echo -n "ஃ v1.0.1"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_julia)

--- a/tests/__sf_section_kubecontext.test.fish
+++ b/tests/__sf_section_kubecontext.test.fish
@@ -8,13 +8,13 @@ end
 
 test "Prints section"
 	(
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold cyan
 		echo -n "☸️  testkube"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_kubecontext)
@@ -30,13 +30,13 @@ test "Changing SPACEFISH_KUBECONTEXT_SYMBOL changes the displayed character"
 	(
 		set SPACEFISH_KUBECONTEXT_SYMBOL "· "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold cyan
 		echo -n "· testkube"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_kubecontext)
@@ -47,13 +47,13 @@ test "Changing SPACEFISH_KUBECONTEXT_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_KUBECONTEXT_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold cyan
 		echo -n "☸️  testkube"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_kubecontext)
@@ -64,13 +64,13 @@ test "Changing SPACEFISH_KUBECONTEXT_SUFFIX changes the character suffix"
 		set sf_exit_code 0
 		set SPACEFISH_KUBECONTEXT_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold cyan
 		echo -n "☸️  testkube"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_kubecontext)

--- a/tests/__sf_section_node.test.fish
+++ b/tests/__sf_section_node.test.fish
@@ -16,13 +16,13 @@ test "Prints section when node_modules is present"
 	(
 		mkdir /tmp/tmp-spacefish/node_modules
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold green
 		echo -n "⬢ v9.8.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_node)
@@ -32,13 +32,13 @@ test "Prints section when package.json is present"
 	(
 		touch /tmp/tmp-spacefish/package.json
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold green
 		echo -n "⬢ v9.8.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_node)
@@ -54,13 +54,13 @@ test "Prints nvm version when nvm is installed"
 		set -e sf_node_version
 		mock nvm current 0 "echo \"v9.8.0\""
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold green
 		echo -n "⬢ v9.8.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_node)
@@ -74,13 +74,13 @@ test "Prints cached nvm version if previously used"
 		set NVM_BIN "path_to_bin"
 		mock nvm current 0
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold green
 		echo -n "⬢ v1.2.3"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_node)
@@ -91,13 +91,13 @@ test "Prints nodenv version when nodenv is installed"
 		mkdir /tmp/tmp-spacefish/node_modules
 		mock nodenv version-name 0 "echo \"v9.8.0\""
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold green
 		echo -n "⬢ v9.8.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_node)
@@ -129,13 +129,13 @@ test "Changing SPACEFISH_NODE_SYMBOL changes the displayed character"
 		mock nvm current 0 "echo \"v9.8.0\""
 		set SPACEFISH_NODE_SYMBOL "· "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold green
 		echo -n "· v9.8.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_node)
@@ -147,13 +147,13 @@ test "Changing SPACEFISH_NODE_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_NODE_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold green
 		echo -n "⬢ v9.8.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_node)
@@ -165,13 +165,13 @@ test "Changing SPACEFISH_NODE_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_NODE_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold green
 		echo -n "⬢ v9.8.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_node)

--- a/tests/__sf_section_php.test.fish
+++ b/tests/__sf_section_php.test.fish
@@ -18,13 +18,13 @@ test "Prints section when composer.json is present"
 	(
 		touch /tmp/tmp-spacefish/composer.json
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold blue
 		echo -n "🐘 v7.1.16"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_php)
@@ -34,13 +34,13 @@ test "Prints section when a *.php file is present"
 	(
 		touch /tmp/tmp-spacefish/testfile.php
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold blue
 		echo -n "🐘 v7.1.16"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_php)
@@ -55,13 +55,13 @@ test "Changing SPACEFISH_PHP_SYMBOL changes the displayed character"
 		touch /tmp/tmp-spacefish/composer.json
 		set SPACEFISH_PHP_SYMBOL "· "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold blue
 		echo -n "· v7.1.16"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_php)
@@ -73,13 +73,13 @@ test "Changing SPACEFISH_PHP_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_PHP_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold blue
 		echo -n "🐘 v7.1.16"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_php)
@@ -91,13 +91,13 @@ test "Changing SPACEFISH_PHP_SUFFIX changes the character suffix"
 		set sf_exit_code 0
 		set SPACEFISH_PHP_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold blue
 		echo -n "🐘 v7.1.16"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_php)

--- a/tests/__sf_section_pyenv.test.fish
+++ b/tests/__sf_section_pyenv.test.fish
@@ -16,13 +16,13 @@ test "Prints section when requirements.txt is present"
 	(
 		touch /tmp/tmp-spacefish/requirements.txt
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold yellow
 		echo -n "🐍 3.7.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_pyenv)
@@ -32,13 +32,13 @@ test "Prints section when a *.py file is present"
 	(
 		touch /tmp/tmp-spacefish/testfile.py
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold yellow
 		echo -n "🐍 3.7.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_pyenv)
@@ -53,13 +53,13 @@ test "Changing SPACEFISH_PYENV_SYMBOL changes the displayed character"
 		touch /tmp/tmp-spacefish/requirements.txt
 		set SPACEFISH_PYENV_SYMBOL "· "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold yellow
 		echo -n "· 3.7.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_pyenv)
@@ -71,13 +71,13 @@ test "Changing SPACEFISH_PYENV_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_PYENV_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold yellow
 		echo -n "🐍 3.7.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_pyenv)
@@ -89,13 +89,13 @@ test "Changing SPACEFISH_PYENV_SUFFIX changes the character suffix"
 		set sf_exit_code 0
 		set SPACEFISH_PYENV_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold yellow
 		echo -n "🐍 3.7.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_pyenv)

--- a/tests/__sf_section_rust.test.fish
+++ b/tests/__sf_section_rust.test.fish
@@ -16,13 +16,13 @@ test "Prints section when Cargo.toml is present"
 	(
 		touch /tmp/tmp-spacefish/Cargo.toml
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold red
 		echo -n "𝗥 v1.28.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_rust)
@@ -32,13 +32,13 @@ test "Prints section when a *.rs file is present"
 	(
 		touch /tmp/tmp-spacefish/testfile.rs
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold red
 		echo -n "𝗥 v1.28.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_rust)
@@ -53,13 +53,13 @@ test "Changing SPACEFISH_RUST_SYMBOL changes the displayed character"
 		touch /tmp/tmp-spacefish/Cargo.toml
 		set SPACEFISH_RUST_SYMBOL "· "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold red
 		echo -n "· v1.28.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_rust)
@@ -71,13 +71,13 @@ test "Changing SPACEFISH_RUST_PREFIX changes the character prefix"
 		set sf_exit_code 0
 		set SPACEFISH_RUST_PREFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 		set_color --bold red
 		echo -n "𝗥 v1.28.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_rust)
@@ -89,13 +89,13 @@ test "Changing SPACEFISH_RUST_SUFFIX changes the character suffix"
 		set sf_exit_code 0
 		set SPACEFISH_RUST_SUFFIX ·
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold red
 		echo -n "𝗥 v1.28.0"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n "·"
 		set_color normal
 	) = (__sf_section_rust)
@@ -106,13 +106,13 @@ test "Prints verbose version when configured to do so"
 		touch /tmp/tmp-spacefish/Cargo.toml
 		set SPACEFISH_RUST_VERBOSE_VERSION true
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "via "
 		set_color normal
 		set_color --bold red
 		echo -n "𝗥 v1.28.0-nightly"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_rust)

--- a/tests/__sf_section_time.test.fish
+++ b/tests/__sf_section_time.test.fish
@@ -26,13 +26,13 @@ test "Enabling time! 24-hour by default"
 	(
 		set SPACEFISH_TIME_SHOW true
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold yellow
 		echo -n "03:00:21"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_time)
@@ -43,13 +43,13 @@ test "Enabling time with 12-hour instead"
 		set SPACEFISH_TIME_SHOW true
 		set SPACEFISH_TIME_12HR true
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold yellow
 		echo -n "03:00:21"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_time)
@@ -60,7 +60,7 @@ test "Show the date too"
 		set SPACEFISH_TIME_SHOW true
 		set SPACEFISH_DATE_SHOW true
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold yellow
@@ -68,7 +68,7 @@ test "Show the date too"
 		echo -n " "
 		echo -n "03:00:21"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_time)
@@ -80,12 +80,12 @@ test "Custom date/time format"
 		set SPACEFISH_TIME_FORMAT (date '+%H') # Unix timestamp
 		set SPACEFISH_TIME_PREFIX "" # Get rid of "at " prefix.
 
-		set_color --bold fff
+		set_color --bold
 		set_color normal
 		set_color --bold yellow
 		echo -n "03"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_time)
@@ -96,13 +96,13 @@ test "What is the time? Purple?!"
 		set SPACEFISH_TIME_SHOW true
 		set SPACEFISH_TIME_COLOR purple
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "at "
 		set_color normal
 		set_color --bold purple
 		echo -n "03:00:21"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_time)

--- a/tests/__sf_section_user.test.fish
+++ b/tests/__sf_section_user.test.fish
@@ -12,13 +12,13 @@ test "Displays user when different from logname"
 	(
 		set USER spacefishUser
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "with "
 		set_color normal
 		set_color --bold yellow
 		echo -n "spacefishUser"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_user)
@@ -28,13 +28,13 @@ test "Displays user when UID = 0"
 	(
 		set UID 0
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "with "
 		set_color normal
 		set_color --bold yellow
 		echo -n $USER
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_user)
@@ -44,13 +44,13 @@ test "Displays user when there's an SSH connection"
 	(
 		set SSH_CONNECTION "192.168.0.100 12345 192.168.0.101 22"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "with "
 		set_color normal
 		set_color --bold yellow
 		echo -n $USER
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_user)
@@ -60,13 +60,13 @@ test "Changes user color when logged in as root"
 	(
 		set USER root
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "with "
 		set_color normal
 		set_color --bold red
 		echo -n root
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_user)
@@ -76,13 +76,13 @@ test "Displays user when SPACEFISH_USER_SHOW is set to \"always\""
 	(
 		set SPACEFISH_USER_SHOW always
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "with "
 		set_color normal
 		set_color --bold yellow
 		echo -n $USER
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_user)

--- a/tests/__sf_section_vi_mode.test.fish
+++ b/tests/__sf_section_vi_mode.test.fish
@@ -9,13 +9,13 @@ end
 
 test "Prints section when fish_vi_key_bindigs is set"
 	(
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 		set_color --bold white
 		echo -n "[I]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_vi_mode)
@@ -26,13 +26,13 @@ test "Prints SPACEFISH_VI_MODE_VISUAL when fish_bind_mode is visual"
 		set fish_bind_mode visual
 		set SPACEFISH_VI_MODE_VISUAL "-V-"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 		set_color --bold white
 		echo -n $SPACEFISH_VI_MODE_VISUAL
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_vi_mode)
@@ -43,13 +43,13 @@ test "Prints SPACEFISH_VI_MODE_REPLACE_ONE when fish_bind_mode is replace_one"
 		set fish_bind_mode replace_one
 		set SPACEFISH_VI_MODE_REPLACE_ONE "-R-"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 		set_color --bold white
 		echo -n $SPACEFISH_VI_MODE_REPLACE_ONE
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_vi_mode)
@@ -60,13 +60,13 @@ test "Prints SPACEFISH_VI_MODE_NORMAL when fish_bind_mode is normal"
 		set fish_bind_mode default
 		set SPACEFISH_VI_MODE_NORMAL "-N-"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 		set_color --bold white
 		echo -n $SPACEFISH_VI_MODE_NORMAL
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_vi_mode)
@@ -77,13 +77,13 @@ test "Prints SPACEFISH_VI_MODE_INSERT when fish_bind_mode is insert"
 		set fish_bind_mode insert
 		set SPACEFISH_VI_MODE_INSERT "-I-"
 
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 		set_color --bold white
 		echo -n $SPACEFISH_VI_MODE_INSERT
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_vi_mode)
@@ -93,13 +93,13 @@ test "Prints prefix when SPACEFISH_VI_MODE_PREFIX is set"
 	(
 		set SPACEFISH_VI_MODE_PREFIX "VIM "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n "$SPACEFISH_VI_MODE_PREFIX"
 		set_color normal
 		set_color --bold white
 		echo -n "[I]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_vi_mode)
@@ -109,13 +109,13 @@ test "Prints suffix when SPACEFISH_VI_MODE_SUFFIX is set"
 	(
 		set SPACEFISH_VI_MODE_SUFFIX " VIM "
 
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 		set_color --bold white
 		echo -n "[I]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n $SPACEFISH_VI_MODE_SUFFIX
 		set_color normal
 	) = (__sf_section_vi_mode)
@@ -125,13 +125,13 @@ test "Use color from SPACEFISH_VI_MODE_COLOR"
 	(
 		set SPACEFISH_VI_MODE_COLOR red
 
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 		set_color --bold red
 		echo -n "[I]"
 		set_color normal
-		set_color --bold fff
+		set_color --bold
 		echo -n " "
 		set_color normal
 	) = (__sf_section_vi_mode)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the `#fff` color from section prefixes and suffixes to make them visible by default on light terminal themes.

**BREAKING CHANGE:** Because prefix and suffix colors are no longer set to #fff, the color of prefix and suffix will be set to the default foreground color of your shell.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #132 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
