### PR TITLE
Add option to display current commit id in git info prompt

### DIFF
--- a/functions/__sf_section_git.fish
+++ b/functions/__sf_section_git.fish
@@ -23,6 +23,7 @@ function __sf_section_git -d "Display the git branch and status"
 	[ $SPACEFISH_GIT_SHOW = false ]; and return
 
 	set -l git_branch (__sf_section_git_branch)
+	set -l git_commit (__sf_section_git_commit)
 	set -l git_status (__sf_section_git_status)
 
 	[ -z $git_branch ]; and return
@@ -30,6 +31,6 @@ function __sf_section_git -d "Display the git branch and status"
 	__sf_lib_section \
 		fff \
 		$SPACEFISH_GIT_PREFIX \
-		"$git_branch$git_status" \
+		"$git_branch$git_commit$git_status" \
 		$SPACEFISH_GIT_SUFFIX
 end

--- a/functions/__sf_section_git_commit.fish
+++ b/functions/__sf_section_git_commit.fish
@@ -1,0 +1,28 @@
+#
+# Git branch
+#
+
+function __sf_section_git_commit -d "Format the displayed commit id"
+	# ------------------------------------------------------------------------------
+	# Configuration
+	# ------------------------------------------------------------------------------
+
+	__sf_util_set_default SPACEFISH_GIT_COMMIT_SHOW false
+	__sf_util_set_default SPACEFISH_GIT_COMMIT_PREFIX @
+	__sf_util_set_default SPACEFISH_GIT_COMMIT_SUFFIX ""
+	__sf_util_set_default SPACEFISH_GIT_COMMIT_COLOR '#008800'
+
+	# ------------------------------------------------------------------------------
+	# Section
+	# ------------------------------------------------------------------------------
+
+	[ $SPACEFISH_GIT_COMMIT_SHOW = false ]; and return
+
+	set -l git_commit (__sf_util_git_commit)
+
+	[ -z $git_commit ]; and return
+
+	__sf_lib_section \
+		$SPACEFISH_GIT_COMMIT_COLOR \
+		$SPACEFISH_GIT_COMMIT_PREFIX$git_commit$SPACEFISH_GIT_COMMIT_SUFFIX
+end

--- a/functions/__sf_util_git_commit.fish
+++ b/functions/__sf_util_git_commit.fish
@@ -1,0 +1,7 @@
+#
+# Git commit
+#
+
+function __sf_util_git_commit -d "Display the current commit id"
+	echo (command git rev-parse --short=7 HEAD 2>/dev/null)
+end


### PR DESCRIPTION
Add option to display current commit id in git info prompt

## Description
With the same semantic as for SPACEFISH_GIT_BRANCH_* setup a commit id
is displayed right next to the branch name. From my own experience of
setting up a prompt git is likely to require its own "order" mechanism
as PROMPT and RPROMPT already have in spacefish. This is not a matter
of this PR but something to concern if this gets accepted as I might add
other stuff regarding git as well. I have the status info string (i.e.
the symbols for "staged", "delete", "modified", etc.) in my RPROMPT for
example and I plan to modify spacefish's git module to support that.

## Motivation and Context
Showing additional information about the git repository is good!
👍 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

https://www.dropbox.com/s/g1d98o9crlkvaei/Screenshot%202019-01-11%2012.43.52.png?dl=0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] ~I have updated the tests accordingly.~