### PR TITLE
ci: lock the fishtape test dependency to v1

### DIFF
--- a/tests/run.fish
+++ b/tests/run.fish
@@ -10,7 +10,7 @@ if test ! -f $tmpDir/.config/fish/functions/fisher.fish
 end
 
 # Install fishtape and local spacefish into temp env
-env HOME=$tmpDir fish -c "fisher add jorgebucaran/fishtape matchai/fish-mock $gitRoot"
+env HOME=$tmpDir fish -c "fisher add jorgebucaran/fishtape@7426171 matchai/fish-mock $gitRoot"
 env HOME=$tmpDir fish -c "fish_prompt"
 
 if test (count $argv) -gt 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
[Fishtape v2](https://github.com/jorgebucaran/fishtape/releases/tag/2.0.0) was released today, which breaks our tests.
Until we migrate to using fishtape v2, we'll keep the release of fishtape locked to the last commit of fishtape v1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
