### PR TITLE
feat: add `SPACEFISH_PROMPT_BOLD` option

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -87,7 +87,7 @@ echo $SPACEFISH_VERSION
 
 ## `__sf_lib_section <color> [prefix] <content> [suffix]`
 
-This function prints out the prompt section prefixed with `prefix`, suffixed with `suffix` and `content` formatted to display in `color`. The **Bold** style is applied by default.
+This function prints out the prompt section prefixed with `prefix`, suffixed with `suffix` and `content` formatted to display in `color`. The **Bold** style is applied unless `SPACEFISH_PROMPT_BOLD` is `false`.
 
 `prefix`, `suffix` and `content` can contain `set_color` to set an additional foreground color, background color or other formatting styles. Read more about `set_color` in the [set_color - set the terminal color](https://fishshell.com/docs/current/commands.html#set_color) section of the Fish Shell documentation.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -25,6 +25,7 @@ This group of options defines a behavior of prompt and standard parameters for s
 
 | Variable | Default | Meaning |
 | :--- | :---: | --- |
+| `SPACEFISH_PROMPT_BOLD` | `true` | Toggle font weight of prompt components |
 | `SPACEFISH_PROMPT_ADD_NEWLINE` | `true` | Adds a newline character before each prompt line |
 | `SPACEFISH_PROMPT_SEPARATE_LINE` | `true` | Make the prompt span across two lines |
 | `SPACEFISH_PROMPT_FIRST_PREFIX_SHOW` | `false` | Shows a prefix of the first section in prompt |

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -7,6 +7,7 @@ function fish_prompt
 	# Configuration
 	# ------------------------------------------------------------------------------
 
+	__sf_util_set_default SPACEFISH_PROMPT_BOLD true
 	__sf_util_set_default SPACEFISH_PROMPT_ADD_NEWLINE true
 	__sf_util_set_default SPACEFISH_PROMPT_FIRST_PREFIX_SHOW false
 	__sf_util_set_default SPACEFISH_PROMPT_PREFIXES_SHOW true

--- a/functions/__sf_lib_section.fish
+++ b/functions/__sf_lib_section.fish
@@ -6,23 +6,37 @@ function __sf_lib_section -a color prefix content suffix
 	end
 
 	if test "$sf_prompt_opened" = "true" -a "$SPACEFISH_PROMPT_PREFIXES_SHOW" = "true"
-		# Echo prefixes in bold white
-		set_color --bold
+		if test "$SPACEFISH_PROMPT_BOLD" = "true"
+			# Echo prefixes in bold white
+			set_color --bold
+		end
+
 		echo -e -n -s $prefix
+
 		set_color normal
 	end
 
 	# Set the prompt as having been opened
 	set -g sf_prompt_opened true
 
-	set_color --bold $color
+	if test "$SPACEFISH_PROMPT_BOLD" = "true"
+		set_color --bold $color
+	else
+		set_color $color
+	end
+
 	echo -e -n $content
+
 	set_color normal
 
 	if test "$SPACEFISH_PROMPT_SUFFIXES_SHOW" = "true"
-		# Echo suffixes in bold white
-		set_color --bold
+		if test "$SPACEFISH_PROMPT_BOLD" = "true"
+			# Echo suffixes in bold white
+			set_color --bold
+		end
+
 		echo -e -n -s $suffix
+
 		set_color normal
 	end
 end

--- a/functions/__sf_section_dir.fish
+++ b/functions/__sf_section_dir.fish
@@ -43,7 +43,7 @@ function __sf_section_dir -d "Display the current truncated directory"
 	set dir (__sf_util_truncate_dir $tmp $SPACEFISH_DIR_TRUNC)
 
 	if [ $SPACEFISH_DIR_LOCK_SHOW = true -a ! -w . ]
-		set DIR_LOCK_SYMBOL (set_color $SPACEFISH_DIR_LOCK_COLOR)" $SPACEFISH_DIR_LOCK_SYMBOL"(set_color --bold)
+		set DIR_LOCK_SYMBOL (set_color $SPACEFISH_DIR_LOCK_COLOR)" $SPACEFISH_DIR_LOCK_SYMBOL"(test "$SPACEFISH_PROMPT_BOLD" = "true"; and set_color --bold; or set_color normal)
 	end
 
 	__sf_lib_section \

--- a/tests/__sf_lib_section.test.fish
+++ b/tests/__sf_lib_section.test.fish
@@ -115,3 +115,17 @@ test "Only prints the prefix for the second consecutive section"
 		__sf_lib_section red "prefix 2" "test content 2" "suffix 2"
 	)
 end
+
+test "Prints section in regular font weight when SPACEFISH_PROMPT_BOLD is false"
+	(
+		set SPACEFISH_PROMPT_BOLD false
+
+		echo -n "prefix"
+		set_color normal
+		set_color red
+		echo -n "test content"
+		set_color normal
+		echo -n "suffix"
+		set_color normal
+	) = (__sf_lib_section red prefix "test content" suffix)
+end

--- a/tests/__sf_section_dir.test.fish
+++ b/tests/__sf_section_dir.test.fish
@@ -381,3 +381,22 @@ test "Changing SPACEFISH_DIR_LOCK_SYMBOL changes the symbol"
 		set_color normal
 	) = (__sf_section_dir)
 end
+
+test "Properly prints DIR_LOCK_SYMBOL when SPACEFISH_PROMPT_BOLD is false"
+  (
+		set SPACEFISH_PROMPT_BOLD false
+		set SPACEFISH_DIR_LOCK_SHOW true
+		cd /tmp/tmp-spacefish/writeProtected
+
+		echo -n "in "
+		set_color normal
+		set_color cyan
+		echo -n "tmp/tmp-spacefish/writeProtected"
+		set_color normal
+		set_color red
+		echo -n " "
+		set_color normal
+		echo -n " "
+		set_color normal
+  ) = (__sf_section_dir)
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds an ability to toggle font weight of prompt via `SPACEFISH_PROMPT_BOLD` option

## Motivation and Context
It will be great to have the ability to disable default bold styling of the prompt

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/576520/52683169-b73fae00-2f4a-11e9-912e-66eebf7d7fb6.png">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
