### PR TITLE
Add support for multiple GOPATHs

### DIFF
--- a/functions/__sf_section_golang.fish
+++ b/functions/__sf_section_golang.fish
@@ -32,7 +32,7 @@ function __sf_section_golang -d "Display the current go version if you're inside
 		-o (count *.go) -gt 0 \
 		-o -f Gopkg.yml \
 		-o -f Gopkg.lock \
-		-o ([ -n $GOPATH ]; and string match $GOPATH $PWD)
+		-o ([ (count $GOPATH) -gt 0 ]; and string match $GOPATH $PWD)
 		return
 	end
 


### PR DESCRIPTION
This adds support for multiple entries in the GOPATH variable, which has the benefit that downloaded packages are placed in the path of the first entry of GOPATH while own packages can be managed in the second path.

## Description

I replaced `[ -n $GOPATH ]` by `[ (count $GOPATH) -gt 0 ]` in `functions/__sf_section_golang.fish`.

## Motivation and Context

Closes #157 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

I ran `npm test`.

```
1..204
# tests 204
# pass  204

# ok
```

## Checklist:

- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.