### PR TITLE
Fix typo in git_status section (deleted != unmerged)

### DIFF
--- a/functions/__sf_section_git_status.fish
+++ b/functions/__sf_section_git_status.fish
@@ -53,7 +53,7 @@ function __sf_section_git_status -d "Display the current git status"
 			set git_status deleted $git_status
 		end
 		if test (string match '*U*' $i)
-			set git_status deleted $git_status
+			set git_status unmerged $git_status
 		end
 	end
 


### PR DESCRIPTION
In the git status section, when one has unmerged files, the character for deleted files will appear in the git status section instead.

## Description
Changed 'deleted' to 'unmerged' in the 'if unmerged' block

## Motivation and Context
Show correct character in git status section when there are unmerged files.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/3227558/52915184-c1d9aa80-329e-11e9-9dd6-dfa831681ebd.png)
After:
![image](https://user-images.githubusercontent.com/3227558/52915114-22b4b300-329e-11e9-8585-90da6698ef33.png)

## How Has This Been Tested?
<!--- Updated var locally,  -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Created git repo with unmerged files (merge conflict), saw it displaying incorrect character, made the variable change, started new fish in the same git repo dir and saw it fixed.
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly. (N/A) 
- [] I have updated the tests accordingly. (N/A)
