### PR TITLE
Noticed an error while running tests more than once

### DIFF
--- a/tests/__sf_section_node.test.fish
+++ b/tests/__sf_section_node.test.fish
@@ -103,7 +103,7 @@ test "Prints nodenv version when nodenv is installed"
 
 test "Prints nothing when using the \"system\" version of node with nvm"
 	(
-		mkdir /tmp/tmp-spacefish/node_modules
+		mkdir -p /tmp/tmp-spacefish/node_modules
 		mock nvm current 0 "echo \"system\""
 	) = (__sf_section_node)
 end


### PR DESCRIPTION
Adding -p to the mkdir command makes it so the error is no longer an issue.

What I was seeing:
```
...
ok 127 Prints nodenv version when nodenv is installed
mkdir: /tmp/tmp-spacefish/node_modules: File exists
ok 127 Prints nothing when using the "system" version of node with nvm
...
```