### PR TITLE
Fix typo in venv generic names variables

### DIFF
--- a/functions/__sf_section_venv.fish
+++ b/functions/__sf_section_venv.fish
@@ -10,7 +10,7 @@ function __sf_section_venv -d "Show current virtual Python environment"
 	__sf_util_set_default SPACEFISH_VENV_PREFIX $SPACEFISH_PROMPT_DEFAULT_PREFIX
 	__sf_util_set_default SPACEFISH_VENV_SUFFIX $SPACEFISH_PROMPT_DEFAULT_SUFFIX
 	__sf_util_set_default SPACEFISH_VENV_SYMBOL "·"
-	__sf_util_set_default SPACESHIP_VENV_GENERIC_NAMES virtualenv venv .venv
+	__sf_util_set_default SPACEFISH_VENV_GENERIC_NAMES virtualenv venv .venv
 	__sf_util_set_default SPACEFISH_VENV_COLOR blue
 
 	# ------------------------------------------------------------------------------
@@ -24,7 +24,7 @@ function __sf_section_venv -d "Show current virtual Python environment"
 	test -n "$VIRTUAL_ENV"; or return
 
 	set -l venv (basename $VIRTUAL_ENV)
-	if contains $venv $SPACESHIP_VENV_GENERIC_NAMES
+	if contains $venv $SPACEFISH_VENV_GENERIC_NAMES
 		set venv (basename (dirname $VIRTUAL_ENV))
 	end
 


### PR DESCRIPTION
## Description
I think this there is a leftover from migrating venv section from Spaceship prompt - name of the variable containing venv generic names is `SPACESHIP_VENV_GENERIC_NAMES` instead of `SPACEFISH_VENV_GENERIC_NAMES`

## Motivation and Context
In the documentation name for this var is `SPACEFISH_VENV_GENERIC_NAMES`. If you add a line to config.fish according to the documentation, the generic names array is not updated, cause spaceship does not take var `SPACEFISH_VENV_GENERIC_NAMES` into account, it only looks for `SPACESHIP_VENV_GENERIC_NAMES`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
