### PR TITLE
Fix Unicode test link.

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -36,9 +36,9 @@ This is not an issue with spacefish. Spacefish uses Unicode symbols to represent
 * Verify your terminal emulator supports Unicode characters with this command:
 
   ```sh
-  curl http://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-demo.txt
+  curl https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-demo.txt
   # or
-  wget -O - http://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-demo.txt
+  wget -O - https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-demo.txt
   ```
 * Configure your terminal emulator to use UTF-8 character encoding.
 


### PR DESCRIPTION
## Description
Old link redirected to https which gave an error with `curl`.

## Motivation and Context
See above.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested in Linux Mint 18.3.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
