### PR TITLE
Fix documentation for displaying AWS info

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -227,11 +227,11 @@ Shows selected Amazon Web Services profile configured using  [`AWS_PROFILE`](htt
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
-| `SPACESHIP_AWS_SHOW` | `true` | Show current selected AWS-cli profile or not |
-| `SPACESHIP_AWS_PREFIX` | `using·` | Prefix before the AWS section |
-| `SPACESHIP_AWS_SUFFIX` | `$SPACEFISH_PROMPT_DEFAULT_SUFFIX` | Suffix after the AWS section |
-| `SPACESHIP_AWS_SYMBOL` | `☁️·` | Character to be shown before AWS profile |
-| `SPACESHIP_AWS_COLOR` | `ff8700` | Color of AWS section |
+| `SPACEFISH_AWS_SHOW` | `true` | Show current selected AWS-cli profile or not |
+| `SPACEFISH_AWS_PREFIX` | `using·` | Prefix before the AWS section |
+| `SPACEFISH_AWS_SUFFIX` | `$SPACEFISH_PROMPT_DEFAULT_SUFFIX` | Suffix after the AWS section |
+| `SPACEFISH_AWS_SYMBOL` | `☁️·` | Character to be shown before AWS profile |
+| `SPACEFISH_AWS_COLOR` | `ff8700` | Color of AWS section |
 
 ### Virtualenv (`venv`)
 


### PR DESCRIPTION
## Description

Fix the documentation for configuring the display of AWS info.

## Motivation and Context
`SPACESHIP_AWS_SHOW false` does not suppress the output of AWS information

`SPACEFISH_AWS_SHOW false` suppresses AWS info
`SPACEFISH_VENV_COLOR cccccc` updates the AWS info color

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
