### PR TITLE
docs: Fix typo SPACESHIP to SPACEFISH in README.md

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -80,7 +80,7 @@ Directory is always shown and truncated to the value of `SPACEFISH_DIR_TRUNC`. W
 | `SPACEFISH_DIR_COLOR` | `cyan` | Color of directory section |
 | `SPACEFISH_DIR_PREFIX` | `in·` | Prefix before current directory |
 | `SPACEFISH_DIR_LOCK_SHOW` | `true` | Show directory write-protected symbol |
-| `SPACESHIP_DIR_LOCK_SYMBOL` | ![·🔒](https://user-images.githubusercontent.com/11844760/47611530-7bf99c00-da8d-11e8-95da-f4ec1f23203a.png) | The symbol displayed if directory is write-protected (requires powerline patched font) |
+| `SPACEFISH_DIR_LOCK_SYMBOL` | ![·🔒](https://user-images.githubusercontent.com/11844760/47611530-7bf99c00-da8d-11e8-95da-f4ec1f23203a.png) | The symbol displayed if directory is write-protected (requires powerline patched font) |
 | `SPACESHIP_DIR_LOCK_COLOR` | `red` | Color for the lock symbol |
 
 ### Hostname \(`host`\)


### PR DESCRIPTION
## Description
`SPACEFISH_DIR_LOCK_SYMBOL` was `SPACESHIP_DIR_LOCK_SYMBOL` in the README.

## How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
