### PR TITLE
Show Julia prompt only for project directories

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -173,7 +173,7 @@ If you set `SPACEFISH_NODE_DEFAULT_VERSION` to the default Node.js version and y
 
 ### Julia \(`julia`\)
 
-Julia section is shown only in directories that contain any file with `.jl` extension.
+Julia section is shown only in directories that contain `Project.toml` or `JuliaProject.toml`.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/functions/__sf_section_julia.fish
+++ b/functions/__sf_section_julia.fish
@@ -23,8 +23,11 @@ function __sf_section_julia -d "Display julia version"
 	# Show Julia version only if julia is installed
 	type -q julia; or return
 
-	# Show julia version only when pwd has *.jl file(s)
-	[ (count *.jl) -gt 0 ]; or return
+	# Show versions only for Julia-specific folders
+	if not test -f Project.toml \
+		-o -f JuliaProject.toml
+		return
+	end
 
 	set -l julia_version (julia --version | grep --color=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
 

--- a/tests/__sf_section_julia.test.fish
+++ b/tests/__sf_section_julia.test.fish
@@ -11,9 +11,25 @@ function teardown
     rm -rf /tmp/tmp-spacefish
 end
 
-test "Prints section when julia is installed and pwd has *.jl file(s)"
+test "Prints section when julia is installed and Project.toml is present"
 	(
-		touch some-julia-file.jl
+		touch Project.toml
+
+		set_color --bold
+		echo -n "is "
+		set_color normal
+		set_color --bold green
+		echo -n "ஃ v1.0.1"
+		set_color normal
+		set_color --bold
+		echo -n " "
+		set_color normal
+	) = (__sf_section_julia)
+end
+
+test "Prints section when julia is installed and JuliaProject.toml is present"
+	(
+		touch JuliaProject.toml
 
 		set_color --bold
 		echo -n "is "
@@ -30,7 +46,7 @@ end
 test "Changing SPACEFISH_JULIA_SYMBOL changes the displayed character"
 	(
 		set SPACEFISH_JULIA_SYMBOL "· "
-		touch some-julia-file.jl
+		touch Project.toml
 
 		set_color --bold
 		echo -n "is "
@@ -47,7 +63,7 @@ end
 test "Changing SPACEFISH_JULIA_PREFIX changes the character prefix"
 	(
 		set SPACEFISH_JULIA_PREFIX ·
-		touch some-julia-file.jl
+		touch Project.toml
 
 		set_color --bold
 		echo -n "·"
@@ -64,7 +80,7 @@ end
 test "Changing SPACEFISH_JULIA_SUFFIX changes the character suffix"
 	(
 		set SPACEFISH_JULIA_SUFFIX ·
-		touch some-julia-file.jl
+		touch Project.toml
 
 		set_color --bold
 		echo -n "is "
@@ -83,11 +99,11 @@ end
 test "Doesn't display section when SPACEFISH_JULIA_SHOW is set to 'false'"
 	(
 		set -g SPACEFISH_JULIA_SHOW false
-		touch some-julia-file.jl
+		touch Project.toml
 
 	) = (__sf_section_julia)
 end
 
-test "Doesn't display section when pwd has no *.jl file"
+test "Doesn't display section when Julia project file is not present"
 	() = (__sf_section_julia)
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Show Julia versions only for Julia-specific folders (i.e. containing `Project.toml` or `JuliaProject.toml`)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Julia packages use convention that the name of package root directory ends with `.jl` which can confuse `spadefish` to incorrectly show Julia prompt for regular directories.

For example, if you had a plain directory (i.e. `./project`) containing a mixed bag of projects and one happened to be a Julia package (i.e. `./project/MyPackage.jl`, then your prompt on `./project` would display Julia version even though it's not meant.

This patch tries to fix this issue by only showing Julia prompt for those projects containing [Project files](https://julialang.github.io/Pkg.jl/v1/glossary/). It will adversely not display Julia prompt on directories only containing plain Julia source files (`*.jl`). It'd be nice if there's a simple pure fish way to count only files, not directories ending with `.jl`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.