### PR TITLE
Support aws-vault instead of named AWS profiles

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -223,7 +223,7 @@ Haskell section is shown only in directories that contain `stack.yaml`.
 
 ### Amazon Web Services (AWS) (`aws`)
 
-Shows selected Amazon Web Services profile configured using  [`AWS_PROFILE`](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html) variable.
+Shows selected Amazon Web Services profile configured using [`AWS_VAULT`](https://github.com/99designs/aws-vault) or [`AWS_PROFILE`](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html) variable.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/functions/__sf_section_aws.fish
+++ b/functions/__sf_section_aws.fish
@@ -25,15 +25,24 @@ function __sf_section_aws -d "Display the selected aws profile"
 	# Ensure the aws command is available
 	type -q aws; or return
 
-	# Early return if there's no AWS_PROFILE, or it's set to default
-	if test -z "$AWS_PROFILE" \
-		-o "$AWS_PROFILE" = "default"
+  set -l PROFILE_NAME
+	
+  # if aws-vault is in use, override profile with that
+  if test -n "$AWS_VAULT"
+    set PROFILE_NAME "$AWS_VAULT"
+  else
+    set PROFILE_NAME "$AWS_PROFILE"
+  end
+
+	# Early return if there's no named profile, or it's set to default
+	if test -z "$PROFILE_NAME" \
+		-o "$PROFILE_NAME" = "default"
 		return
 	end
 
 	__sf_lib_section \
 		$SPACEFISH_AWS_COLOR \
 		$SPACEFISH_AWS_PREFIX \
-		"$SPACEFISH_AWS_SYMBOL""$AWS_PROFILE" \
+		"$SPACEFISH_AWS_SYMBOL""$PROFILE_NAME" \
 		$SPACEFISH_AWS_SUFFIX
 end

--- a/tests/__sf_section_aws.test.fish
+++ b/tests/__sf_section_aws.test.fish
@@ -87,3 +87,19 @@ test "doesn't display the section when SPACEFISH_AWS_SHOW is set to \"false\""
 		set SPACEFISH_AWS_SHOW false
 	) = (__sf_section_aws)
 end
+
+
+test "Prints section when AWS_VAULT is set"
+        (
+                set AWS_VAULT user2
+                set_color --bold
+                echo -n "using "
+                set_color normal
+                set_color --bold ff8700
+                echo -n "☁️ user2"
+                set_color normal
+                set_color --bold
+                echo -n " "
+                set_color normal
+        ) = (__sf_section_aws)
+end


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update the AWS function to optionally retrieve the profile name from the `AWS_VAULT` environment variable instead of `AWS_PROFILE`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When using [99designs/aws-vault](https://github.com/99designs/aws-vault) the variable `AWS_VAULT` is set to indicate which profile has been configured in the environment and the AWS_PROFILE environment variable is not set. This commits makes AWS_VAULT override the profile name.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
