### PR TITLE
Added nix-Shell support

### DIFF
--- a/functions/__sf_section_nix.fish
+++ b/functions/__sf_section_nix.fish
@@ -1,0 +1,32 @@
+# pyenv
+#
+
+function __sf_section_nix -d "Show in nix-shell indicator"
+	# ------------------------------------------------------------------------------
+	# Configuration
+	# ------------------------------------------------------------------------------
+
+	__sf_util_set_default SPACEFISH_NIX_SHOW true
+	__sf_util_set_default SPACEFISH_NIX_PREFIX $SPACEFISH_PROMPT_DEFAULT_PREFIX
+	__sf_util_set_default SPACEFISH_NIX_SUFFIX $SPACEFISH_PROMPT_DEFAULT_SUFFIX
+	__sf_util_set_default SPACEFISH_NIX_SYMBOL "🅽 "
+	__sf_util_set_default SPACEFISH_NIX_COLOR blue
+
+	# ------------------------------------------------------------------------------
+	# Section
+	# ------------------------------------------------------------------------------
+
+	# Show nix-shell python version
+	[ $SPACEFISH_NIX_SHOW = false ]; and return
+
+	# Show nix-shell python version only for Python-specific folders
+	if not test -n "$IN_NIX_SHELL"
+		return
+	end
+
+	__sf_lib_section \
+		$SPACEFISH_NIX_COLOR \
+		$SPACEFISH_NIX_PREFIX \
+		"$SPACEFISH_NIX_SYMBOL" \
+		$SPACEFISH_NIX_SUFFIX
+end

--- a/functions/__sf_section_nix.fish
+++ b/functions/__sf_section_nix.fish
@@ -1,4 +1,4 @@
-# pyenv
+# nix
 #
 
 function __sf_section_nix -d "Show in nix-shell indicator"
@@ -16,10 +16,10 @@ function __sf_section_nix -d "Show in nix-shell indicator"
 	# Section
 	# ------------------------------------------------------------------------------
 
-	# Show nix-shell python version
+	# Show in-nix-shell indicator
 	[ $SPACEFISH_NIX_SHOW = false ]; and return
 
-	# Show nix-shell python version only for Python-specific folders
+	# Show nix-shell symbol only in a nix shell
 	if not test -n "$IN_NIX_SHELL"
 		return
 	end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -13,7 +13,7 @@ function fish_prompt
 	__sf_util_set_default SPACEFISH_PROMPT_SUFFIXES_SHOW true
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_PREFIX "via "
 	__sf_util_set_default SPACEFISH_PROMPT_DEFAULT_SUFFIX " "
-	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package node ruby golang php rust haskell julia elixir docker aws venv conda pyenv dotnet kubecontext exec_time line_sep battery vi_mode jobs exit_code char
+	__sf_util_set_default SPACEFISH_PROMPT_ORDER time user dir host git package nix node ruby golang php rust haskell julia elixir docker aws venv conda pyenv dotnet kubecontext exec_time line_sep battery vi_mode jobs exit_code char
 
 	# ------------------------------------------------------------------------------
 	# Sections


### PR DESCRIPTION

## Description
Displays an indicator in the prompt if the shell is started with nix-shell.

## Motivation and Context
Using NixOs and working with nix-shells, I want to have an indicator in the prompt that shows whether I'm in a nix-shell or not

## Types of changes
A new __sf_section_nix.fish file has been added.
The PROMPT_ORDER has been expanded.