### PR TITLE
feat: strip ruby from ruby version

### DIFF
--- a/functions/__sf_section_ruby.fish
+++ b/functions/__sf_section_ruby.fish
@@ -45,6 +45,11 @@ function __sf_section_ruby -d "Show current version of Ruby"
 
 	[ -z "$ruby_version" -o "$ruby_version" = "system" ]; and return
 
+	# Remove 'ruby-' before ruby version that starts with ruby
+	if test -n (echo (string match -r "^ruby-" "$ruby_version"))
+		set ruby_version (echo (string replace -r "^ruby-" "" "$ruby_version"))
+	end
+
 	# Add 'v' before ruby version that starts with a number
 	if test -n (echo (string match -r "^[0-9].+\$" "$ruby_version"))
 		set ruby_version "v$ruby_version"


### PR DESCRIPTION
## Description
Chruby reports versions as `ruby-2.7.2` for MRI, `jruby-9.2.13.0` for JRuby, etc. This PR strips `ruby-` from MRI version. 

## Motivation and Context
Ruby prefix on version number for MRI is redundant.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that no other PR duplicates mine
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
